### PR TITLE
Work around session cookie security restrictions in VSCode webview

### DIFF
--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -99,7 +99,6 @@ ClassMethod HandleRequest(pagePath As %String, Output handled As %Boolean = 0, O
                         else:
                             self.send_error(403)
                 */
-                merge ^mtemptsl($i(^mtemptsl)) = %request.Data
                 set reference = "%request.Data"
                 for {
                     set reference = $query(@reference)

--- a/csp/webuidriver.csp
+++ b/csp/webuidriver.csp
@@ -7,6 +7,16 @@
 
     new $NAMESPACE
     set $NAMESPACE = namespace
+	
+	try {
+		if (%request.UserAgent [ " Code/") {
+			// Workaround for VSCode webview
+			set %session.SessionScope = 0 // none; allowed because...
+			set %session.SecureSessionCookie = 1 // secure flag on session cookie - will be ignored over http, but that's OK because we already have it
+		}
+	} catch e {
+		// ignore; may occur on platform versions without the above properties
+	}
 
 	// Serve static content when appropriate.
 	// index.html
@@ -20,7 +30,7 @@
 		do %request.Set("FILE","/isc/studio/usertemplates/gitsourcecontrol/"_$Piece(url,%base,2,*))
 		kill %base
 		set %stream = 1
-		do ##class(%CSP.StreamServer).FileClassify(url,.type,,.charset)
+		do ##class(%CSP.StreamServer).FileClassify($Piece(url,".",*),.type,,.charset)
 		set %response.ContentType = type
 		if ($Get(charset) = "") {
 			set %response.NoCharSetConvert = 1


### PR DESCRIPTION
This works even for http because we have the session cookie to start with and http->https is allowed.
Also removes a debug global set.

@isc-svelury can you take a look and see if this fixes the issues on your latest IRIS for Health instance? You'll also need to uncheck "Prevent login CSRF attack" on the /isc/studio/usertemplates web application.