### PR TITLE
Minor bug fix to check for data in args before referencing it

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1105,8 +1105,12 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
 
     for i=1:1:$g(args) 
     {
-        set newArgs($i(newArgs)) = args(i)
+        if ($DATA(args(i))) {
+            set newArgs($i(newArgs)) = args(i)
+        }
+        
     }
+    
     set outLog = ##class(%Library.File).TempFilename()
     set errLog = ##class(%Library.File).TempFilename()
     set returnCode = $zf(-100,"/STDOUT="_$$$QUOTE(outLog)_" /STDERR="_$$$QUOTE(errLog)_$Case(inFile, "":"", :" /STDIN="_inFile),"git",newArgs...)


### PR DESCRIPTION
If the` args` parameter in `RunGitCommandWithInput()` is empty, then it throws an error. This fix checks for data in `args` before attempting to reference it. 

Came across this issue when I was trying to `git branch`.