### PR TITLE
Commit Explorer view now works for merge commits as well.

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -1428,7 +1428,7 @@ webui.CommitView = function(historyView) {
         currentCommit = entry.commit;
         self.showDiff();
         buttonBox.select(0);
-        diffView.update("show", [entry.commit]);
+        diffView.update("show -p --diff-merges=separate", [entry.commit]);
         treeView.update(entry.tree);
     };
 

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -1428,7 +1428,7 @@ webui.CommitView = function(historyView) {
         currentCommit = entry.commit;
         self.showDiff();
         buttonBox.select(0);
-        diffView.update("show", [entry.commit]);
+        diffView.update("show -p --diff-merges=separate", [entry.commit]);
         treeView.update(entry.tree);
     };
 


### PR DESCRIPTION
The merge-diff format is now separate instead of the default combined. This does not affect regular commits. Turned out to be a much simpler fix than I initially expected. 