### PR TITLE
Add missing bracket in release git-webui.css

### DIFF
--- a/git-webui/release/share/git-webui/webui/css/git-webui.css
+++ b/git-webui/release/share/git-webui/webui/css/git-webui.css
@@ -204,7 +204,7 @@ body {
   background-color: inherit !important;
   color: inherit !important;
   border: none;
-
+}
 #sidebar .btn-branch {
   background-color: inherit !important;
   color: inherit !important;


### PR DESCRIPTION
I think this was probably an artifact of the VSCode "random undo" bug - I should have installed from the PR branch.
Re-running grunt release fixed this.