### PR TITLE
Removing from source control now works

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -9,6 +9,8 @@ Parameter InstallNamespace = "%SYS";
 
 Parameter Slash = {$case($system.Version.GetOS(),"Windows":"\",:"/")};
 
+Parameter NotMySlash = {$case($system.Version.GetOS(),"Windows":"/",:"\")};
+
 /// Name of the file with version controlled items
 Parameter SCListFilename = "sc-list.txt";
 
@@ -120,6 +122,20 @@ ClassMethod AddSlash(path As %String) As %String
         set path = path_..#Slash
     }
     quit path
+}
+
+ClassMethod FixSlashes(path As %String) As %String
+{
+    set fixedPath = ""
+    if (path '= ""){
+        for i=1:1:$LENGTH(path,..#NotMySlash){
+            if (($PIECE(path, ..#NotMySlash, i) '= "") || (i=1)) {
+                set fixedPath = fixedPath_$PIECE(path, ..#NotMySlash, i)_..#Slash
+            }
+        }
+    }
+    
+    quit fixedPath
 }
 
 ClassMethod IsMenuGitCommand(menuItemName As %String) As %Boolean [ CodeMode = expression ]
@@ -402,6 +418,13 @@ ClassMethod AddToSourceControl(InternalName As %String) As %Status
     quit ec
 }
 
+ClassMethod RemoveFromGit(InternalName)
+{
+    #dim fullName = ##class(Utils).FullExternalName(InternalName)
+    do ..RunGitCommand("rm",.errStream,.outStream,"--cached", fullName)
+    do errStream.OutputToDevice()
+}
+
 ClassMethod DeleteExternalsForItem(InternalName As %String) As %Status
 {
     #dim type as %String = ..Type(InternalName)
@@ -425,6 +448,7 @@ ClassMethod DeleteExternalsForItem(InternalName As %String) As %Status
                 if 'sc {
                     set ec = $$$ADDSC(ec, sc)
                 }
+                do ..RemoveFromGit(item)
             }
         }
     } else {
@@ -435,6 +459,7 @@ ClassMethod DeleteExternalsForItem(InternalName As %String) As %Status
 
 ClassMethod RemoveFromSourceControl(InternalName As %String) As %Status
 {
+    write !
     #dim sc as %Status = $$$OK
     for i = 1:1:$length(InternalName, ",") {
         #dim tsc as %Status = $$$OK
@@ -828,8 +853,28 @@ ClassMethod ImportItem(InternalName As %String, force As %Boolean = 0, verbose A
 ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
 {
     #define DoNotLoad 1
-    set res = $system.OBJ.ImportDir(..TempFolder(),"*.xml","-d",.err,1, .itemList, $$$DoNotLoad)
     
+    set mappingFileType = $order($$$SourceMapping(""))
+    while (mappingFileType '= "") {
+
+        set mappingCoverage = $order($$$SourceMapping(mappingFileType, ""))
+
+        while (mappingCoverage '= ""){
+
+            set mappedRelativePath = $$$SourceMapping(mappingFileType, mappingCoverage)
+            set mappedFilePath = ..FixSlashes(..TempFolder()_(mappedRelativePath))
+            
+            if (##class(%File).DirectoryExists(mappedFilePath)){
+                set res = $system.OBJ.ImportDir(mappedFilePath,,"-d",.err,1, .tempItemList, $$$DoNotLoad)
+                merge itemList = tempItemList
+            }
+
+            set mappingCoverage = $order($$$SourceMapping(mappingFileType, mappingCoverage))
+        }
+
+        set mappingFileType = $order($$$SourceMapping(mappingFileType))
+    }
+
     if '$data(itemList) && $$$ISERR(res) {
         quit res
     }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -9,8 +9,6 @@ Parameter InstallNamespace = "%SYS";
 
 Parameter Slash = {$case($system.Version.GetOS(),"Windows":"\",:"/")};
 
-Parameter NotMySlash = {$case($system.Version.GetOS(),"Windows":"/",:"\")};
-
 /// Name of the file with version controlled items
 Parameter SCListFilename = "sc-list.txt";
 
@@ -122,20 +120,6 @@ ClassMethod AddSlash(path As %String) As %String
         set path = path_..#Slash
     }
     quit path
-}
-
-ClassMethod FixSlashes(path As %String) As %String
-{
-    set fixedPath = ""
-    if (path '= ""){
-        for i=1:1:$LENGTH(path,..#NotMySlash){
-            if (($PIECE(path, ..#NotMySlash, i) '= "") || (i=1)) {
-                set fixedPath = fixedPath_$PIECE(path, ..#NotMySlash, i)_..#Slash
-            }
-        }
-    }
-    
-    quit fixedPath
 }
 
 ClassMethod IsMenuGitCommand(menuItemName As %String) As %Boolean [ CodeMode = expression ]
@@ -863,7 +847,7 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
         while (mappingCoverage '= ""){
 
             set mappedRelativePath = $$$SourceMapping(mappingFileType, mappingCoverage)
-            set mappedFilePath = ..FixSlashes(..TempFolder()_(mappedRelativePath))
+            set mappedFilePath = ##class(%File).NormalizeFilename(mappedRelativePath, ..TempFolder())
             
             if (##class(%File).DirectoryExists(mappedFilePath)){
                 set res = $system.OBJ.ImportDir(mappedFilePath,,"-d",.err,1, .tempItemList, $$$DoNotLoad)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -453,6 +453,7 @@ ClassMethod DeleteExternalsForItem(InternalName As %String) As %Status
         }
     } else {
         set ec = ..DeleteExternalFile(InternalName)
+        do ..RemoveFromGit(InternalName)
     }
     quit ec
 }


### PR DESCRIPTION
Removing from source control now works as expected. We still don't seem to support removing individual files from Source Control in cases where entire packages were added to source control. A fix for this would be to add individual files to source control instead of the package. Not sure how this would change things though. 

This PR closes #76 :
- Adds a new parameter NotMySlash
- A method to fix slashes in a filepath for the OS
- Finds the files that are being tracked according to mappings. So it now does not look for only XML files. Should that be the default? 
- Deletes files that are no longer in source control (same as before)
- Removes files from git tracking

Please review this more extensively than usual. I might have missed some things because of my limited ObjectScript knowledge. 