### PR TITLE
Preserve filenames for AbstractDocuments

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1239,24 +1239,32 @@ ClassMethod Name(InternalName As %String) As %String
             // Grab the actual name
             set actualName = $classmethod(docclass,"GetOther",InternalName)
             // The actualName is only valid if we get a single .cls as a result
-            if actualName'[",",$zconvert($piece(actualName,".",$length(actualName,".")),"U")="CLS" {
+            if (actualName'[",") && ($zconvert($piece(actualName,".",$length(actualName,".")),"U")="CLS") {
                 // We use what GetOther() gives us, thus Demo.Loan.FindRateProcess.bpl becomes Demo.Loan.FindRateProcess.cls
                 set InternalName = actualName
             }
         }
     }
     
-    if $$CheckProtect^%qccServer(InternalName) quit ""
-    set nam=$piece(InternalName,".",1,*-1),ext=$piece(InternalName,".",*),ext=$zconvert(ext,"u")
-    if nam=""||(ext="") quit ""
+    if $$CheckProtect^%qccServer(InternalName) {
+        quit ""
+    }
+       
+    set nam=$piece(InternalName,".",1,*-1)
+    set ext=$zconvert($piece(InternalName,".",*),"u")
+
+    if (nam="")||(ext=""){
+        quit ""
+    } 
+
     // Any CSP items should be matched against the "/CSP/" mapping in ^Sources
     if InternalName["/" {
         set filename=$$GetFilename^%apiCSP(InternalName)
         //Find if this csp file is located within the ^Sources tree, and return appropriate value
-        if $$$isWINDOWS {
-            if $zconvert($extract(filename,1,$length($$$SourceRoot)),"l")=$zconvert($$$SourceRoot,"l") quit $extract(filename,$length($$$SourceRoot)+1,*)
-        } else {
-            if $extract(filename,1,$length($$$SourceRoot))=$$$SourceRoot quit $extract(filename,$length($$$SourceRoot)+1,*)
+        if ($$$isWINDOWS) && ($zconvert($extract(filename,1,$length($$$SourceRoot)),"l")=$zconvert($$$SourceRoot,"l")){
+            quit $extract(filename,$length($$$SourceRoot)+1,*)
+        } elseif $extract(filename,1,$length($$$SourceRoot))=$$$SourceRoot{
+            quit $extract(filename,$length($$$SourceRoot)+1,*)
         }
         //Do not support manipulating files in the /itemsetsourcelink* csp app which are not inside of the namespace's ^Sources tree
         if InternalName["itemsetsourcelink" {
@@ -1266,29 +1274,55 @@ ClassMethod Name(InternalName As %String) As %String
         // Any CSP items should be matched against the "/CSP/" mapping if the file is not stored in the ^Sources tree
         set ext="/CSP/"
     }
-    if ext="PRJ",nam["Default_" quit ""
-    if ext="CLS",$$$defClassKeyGet(nam,$$$cCLASSgeneratedby)'="" quit ""
-    set default=0
-    set p=$order($$$SourceMapping(ext,nam)) for  set p=$order($$$SourceMapping(ext,p),-1) quit:p=""  if $extract(nam,1,$length(p))=p,$data(^Sources(ext,p),found) quit
-    if $data(found)=0,$data($$$SourceMapping(ext,"*"),found),'$$$GetSourceMapping(ext,"*","NoFolders") set default=1
-    if $data(found)=0 quit ""
+
+    if (ext="PRJ") && (nam["Default_"){
+        quit ""
+    } 
+
+    if (ext="CLS") && ($$$defClassKeyGet(nam,$$$cCLASSgeneratedby)'=""){
+        quit ""
+    } 
+    
+    set default=1
+    set p=$order($$$SourceMapping(ext,nam))
+    for{
+        set p=$order($$$SourceMapping(ext,p),-1) 
+        quit:p=""  
+        if ($extract(nam,1,$length(p))=p) && ($data(^Sources(ext,p),found)){
+            quit
+        }
+    }
+    if ($data(found)=0) && ($data($$$SourceMapping(ext,"*"),found)) && ('$$$GetSourceMapping(ext,"*","NoFolders")){
+        set default=0
+
+    } elseif $data(found)=0{
+        set found = $zconvert(ext,"L")_"/"
+    }
+
     if InternalName["/" {
         // If no specific mapping was specified (p=""), then return the whole csp filename; otherwise return the name without the mapped piece
         set InternalName=$extract(InternalName,$length(p)+2,*)
         quit $translate(found_$translate(InternalName,"%","_"),"\","/")
-    }
-    if (ext="DFI") {
+    
+    } elseif (ext="DFI") {
         // expected format is <folderName>-<itemName>.<itemType>.DFI; will map to an external file named <folderName>/<itemName>.<itemType>.xml
         // replace the first '-' with '/' to translate Item Folder into subfolder on disk and leave the other dashes as dashes; converts spaces to '_'
         quit $translate(found_$replace($translate(nam,"% ","__"),"-","/",1,1)_".xml","\","/")
-    }
-    if ext="CLS"||(ext="PRJ")||(usertype&&(##class(%RoutineMgr).UserType(InternalName))) {
+    
+    } elseif ext="CLS"||(ext="PRJ")||(usertype&&(##class(%RoutineMgr).UserType(InternalName))) {
         set nam=$translate(nam,"%")
-        if '$$$GetSourceMapping(ext,"*","NoFolders") set nam=$translate(nam,".","/")
+        if '$$$GetSourceMapping(ext,"*","NoFolders"){
+            set nam=$translate(nam,".","/")
+        }
         #; If match ends in '`' character use UDL/CLS format rather than XML format
-        return $translate(found_nam_".cls","\","/")
+        return $translate(found_nam_"."_$zconvert(ext, "l"),"\","/")
     }
-    quit $translate($get(found)_$translate(nam,"%.","_/")_"."_$zconvert(ext,"l"),"\","/")
+
+    if ('default){
+        quit $translate($get(found)_$translate(nam,"%.","_/")_"."_$zconvert(ext,"l"),"\","/")
+    } else {
+        quit $translate($get(found)_nam_"."_$zconvert(ext,"l"),"\","/")
+    }
 }
 
 /*
@@ -1377,10 +1411,10 @@ ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1) A
         }
         if (InternalName="") {
             //take our best guess based on the document extension mapped to that subdirectory
-            set nam=$piece(nam,".",1,$length(nam,".")-1)
+            set nam=$piece(nam,".",1*-1)
             set nam=$translate(nam,"_/","%.")
-            set InternalName=nam_"."_ext
-            if (ext="CLS") {
+            set InternalName=nam_"."_fileExt
+            if (fileExt="cls") {
                 // special handling for possible collissions between % and non-% classes of the same name
                 set alternateInternalName="%"_InternalName
                 set primaryExists=##class(%RoutineMgr).Exists(InternalName), alternateExists=##class(%RoutineMgr).Exists(alternateInternalName)

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -34,6 +34,12 @@ body {
     border-radius: 0 0.25rem 0.25rem 0;
 }
 
+.custom-switch {
+    padding: 0.4rem 0.5rem 0 2.75rem;
+    border: 1px solid #ced4da;
+    border-left: 0px;
+}
+
 hr {
     opacity: 0.15
 }
@@ -54,7 +60,12 @@ hr {
     set param = "MappingsPath"
     kill settings.Mappings
     while ( $Get(%request.Data(param,i)) '= "" ){
+        if ($Get(%request.Data(param,i)) = "NoFolders"){
+            set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i)), $Get(%request.Data(param,i))) = 1
+        }
+
         set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i))) = $Get(%request.Data(param,i))
+
         set i = i+1
     }
     do settings.%Save()
@@ -128,7 +139,7 @@ hr {
             </div>
             <script language="cache" runat=server>
                 set extKey = ""
-                set first = 1
+                set idx = 1
                 for {
                     set covKey = ""
                     set extKey = $ORDER(settings.Mappings(extKey))
@@ -137,19 +148,46 @@ hr {
                         set covKey = $ORDER(settings.Mappings(extKey, covKey))
                         quit:covKey=""
 
-                        if (first = 1) {
-                            set first = 0
-                        }
-                        else {
+                        if (idx '= 1) {
                             &html<<div class="col-sm-3" id="indent-div">
                             </div>>
+                        }                        
+
+                        if ($DATA(settings.Mappings(extKey, covKey)) = 1){
+                            set checked = "checked"
+                            set activated = " active"
+                            set readOnly = ""
+                            set mapPath = settings.Mappings(extKey, covKey)
+                            
+                        } else {
+                            set checked = ""
+                            set activated = ""
+                            set readOnly = "readonly"
+                            set mapPath = "NoFolders"
                         }
 
                         &html<<div class="voca col-sm-7">
                             <div class = "input-group mb-1">
                                 <input type="text" class="form-control" id="MappingsExt" name="MappingsExt" value=#(extKey)# placeholder="Extension">
                                 <input type="text" class="form-control" id="MappingsCov" name="MappingsCov" value=#(covKey)# placeholder="Coverage">
-                                <input type="text" class="form-control" id="MappingsPath" name="MappingsPath" value=#(settings.Mappings(extKey, covKey))# placeholder="Relative path">
+                                <input type="text" class="form-control" id="MappingsPath" name="MappingsPath" value=#(mapPath)# placeholder="Relative path" #(readOnly)#>
+                                <div class="custom-control custom-switch" data-delay='{"show":"1000", "hide":"100"}' data-toggle="tooltip" data-placement="top" title="Switch off to store files in a flat directory structure.">
+                                    <input type="checkbox" class="#("custom-control-input"_activated)#" id=#("noFoldersSwitch"_idx)# #(checked)#>
+                                    <label class="custom-control-label" for=#("noFoldersSwitch"_idx)#>>
+
+                                    if (checked '= ""){
+                                        &html<<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#007bff" class="bi bi-folder-fill" viewBox="0 0 16 16">
+                                            <path d="M9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.825a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31L.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3zm-8.322.12C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139z"/>
+                                        </svg>>                                        
+                                    } else{
+                                        &html<<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-folder-x" viewBox="0 0 16 16">
+                                            <path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181L15.546 8H14.54l.265-2.91A1 1 0 0 0 13.81 4H2.19a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91H9v1H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zm6.339-1.577A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707z"/>
+                                            <path d="M11.854 10.146a.5.5 0 0 0-.707.708L12.293 12l-1.146 1.146a.5.5 0 0 0 .707.708L13 12.707l1.146 1.147a.5.5 0 0 0 .708-.708L13.707 12l1.147-1.146a.5.5 0 0 0-.707-.708L13 11.293l-1.146-1.147z"/>
+                                        </svg>>
+                                    }
+                                    
+                                    &html<</label>
+                                </div>
                                 <div class="input-group-append">
                                     <button type="button" class="btn btn-remove" >
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#dc3545" class="bi bi-dash-circle-fill" viewBox="0 0 16 16">
@@ -159,6 +197,8 @@ hr {
                                 </div>
                             </div>
                         </div>>
+
+                        set idx = idx + 1
                     }
                 }
             </script>
@@ -205,8 +245,12 @@ hr {
 <script src="js/popper.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
 <script type="text/javascript">
+
+previous_path = new Array($(".voca").length).fill("");
 $(function () {
-  $('[data-toggle="tooltip"]').tooltip()
+    $('[data-toggle="tooltip"]').tooltip({
+        trigger: 'hover'
+    });
 })
 $(function()
 {
@@ -235,6 +279,34 @@ $(function()
         return false;
     });
 });
+
+$('[id^=noFoldersSwitch]').click(function(e) {
+
+    $(this).siblings("label").empty()
+    var idx = parseInt($(this)[0].id.split("noFoldersSwitch")[1]);
+
+    if (!$(this).hasClass("active")) {
+        $(this).addClass("active");
+        $(this).siblings("label").append('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#007bff" class="bi bi-folder-fill" viewBox="0 0 16 16">'+
+                                        '<path d="M9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.825a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31L.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3zm-8.322.12C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139z"/>'+
+                                    '</svg>');
+        
+        $(this).parent().siblings("#MappingsPath")[0].value = previous_path[idx-1];
+        $(this).parent().siblings("#MappingsPath")[0].readOnly = false;
+        
+    } else {
+        $(this).removeClass("active");
+        $(this).siblings("label").append('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-folder-x" viewBox="0 0 16 16">'+
+                                        '<path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181L15.546 8H14.54l.265-2.91A1 1 0 0 0 13.81 4H2.19a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91H9v1H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zm6.339-1.577A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707z"/>'+
+                                        '<path d="M11.854 10.146a.5.5 0 0 0-.707.708L12.293 12l-1.146 1.146a.5.5 0 0 0 .707.708L13 12.707l1.146 1.147a.5.5 0 0 0 .708-.708L13.707 12l1.147-1.146a.5.5 0 0 0-.707-.708L13 11.293l-1.146-1.147z"/>'+
+                                    '</svg>');  
+
+        previous_path[idx-1] = $(this).parent().siblings("#MappingsPath").val()
+        $(this).parent().siblings("#MappingsPath")[0].value = "NoFolders";
+        $(this).parent().siblings("#MappingsPath")[0].readOnly = true;
+    }
+});
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
When nested folder structure is not enabled, files are now mapped into folders corresponding to their extension. No further folder nesting occurs.

To enable this behavior, turn off the folder switch in the settings. Note, this only works for a universal file type mapping. So the coverage must be *

This PR also fixes the bug where some file extensions were being changed to `.cls` incorrectly.

Closes #92 and #93 