### PR TITLE
Add Line break in Output window

### DIFF
--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -34,7 +34,7 @@ ClassMethod RemoveUncommitted(FileList, Display = 1, Revert = 0, ActiveCommit = 
     set filename=FileList,SCs=$$$OK
     if $data(FileList)>1 set filename=$order(FileList(""))
     while (filename'="") {
-        if Display write !,filename_" removed from uncommitted list"
+        if Display write !,filename_" removed from uncommitted list",!
         if '..IsUncommitted(filename) set filename=$order(FileList(filename)) continue
         set obj=..OpenUncommitted(filename)
         if (obj.Source="trakcare")&&($data(^SYS("ChangeControlClass"))) {


### PR DESCRIPTION
Minor thing

In RemoveUncommitted, need to add line break after output as output is not cleared between subsequent actions - which is fine and likely preferred - but makes for a confusing run on sentence.

exporting new version of MyTable.lut to /hfs/sys/git/IRISHealth/INTGBUS/lut/MyTable.lut

/hfs/sys/git/IRISHealth/INTGBUS/lut/MyTable.lut removed from uncommitted list <Should be line break here> exporting new version of MySchema_2.5.1.hl7 to /hfs/sys/git/IRISHealth/INTGBUS/hl7/MySchema_2/5/1.hl7

/hfs/sys/git/IRISHealth/INTGBUS/hl7/MySchema_2/5/1.hl7 removed from uncommitted list

Note also the schema is still splitting into separate files on the dots. I thought this was fixed but may have misunderstood. Still looking at this part.