### PR TITLE
Wrapping the other mapping creation in an else block because it makes…

### DIFF
--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -63,9 +63,9 @@ hr {
         if ($Get(%request.Data(param,i)) = "NoFolders"){
             set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i)), $Get(%request.Data(param,i))) = 1
         }
-
-        set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i))) = $Get(%request.Data(param,i))
-
+        else{
+            set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i))) = $Get(%request.Data(param,i))
+        }
         set i = i+1
     }
     do settings.%Save()


### PR DESCRIPTION
… more sense that way and is more consistent in terms of results.