### PR TITLE
Configurability for how class names are changed on export

### DIFF
--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -17,6 +17,9 @@ Property privateKeyFile As %String [ InitialExpression = {##class(SourceControl.
 /// Event handler class for git pull
 Property pullEventClass As %String [ InitialExpression = {##class(SourceControl.Git.Utils).PullEventClass()}, Required ];
 
+/// Character to replace % symbol when importing %-classes into the file systems
+Property percentClassReplace As %String [ InitialExpression = {##class(SourceControl.Git.Utils).PercentClassReplace()} ];
+
 /// Attribution: Git username for user ${username}
 Property gitUserName As %String [ InitialExpression = {##class(SourceControl.Git.Utils).GitUserName()}, Required ];
 
@@ -54,6 +57,7 @@ Method %Save() As %Status
     set @storage@("settings","user",$username,"gitUserEmail") = ..gitUserEmail
     set @storage@("settings","ssh","privateKeyFile") = ..privateKeyFile
     set @storage@("settings","pullEventClass") = ..pullEventClass
+    set @storage@("settings", "percentClassReplace") = ..percentClassReplace
 
     kill @##class(SourceControl.Git.Utils).MappingsNode()
     merge @##class(SourceControl.Git.Utils).MappingsNode() = ..Mappings
@@ -90,4 +94,3 @@ ClassMethod Configure() As %Boolean [ CodeMode = objectgenerator ]
 }
 
 }
-

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -53,6 +53,11 @@ ClassMethod PullEventClass() As %String [ CodeMode = expression ]
 $Get(@..#Storage@("settings","pullEventClass"), ##class(SourceControl.Git.PullEventHandler.Default).%ClassName(1))
 }
 
+ClassMethod PercentClassReplace() As %Status [ CodeMode = expression ]
+{
+$Get(@..#Storage@("settings","percentClassReplace"), "")
+}
+
 /// Returns the current (or previous) value of the flag.
 ClassMethod Locked(newFlagValue As %Boolean) As %Boolean
 {
@@ -1450,7 +1455,7 @@ ClassMethod Name(InternalName As %String) As %String
         quit $translate(found_$replace($translate(nam,"% ","__"),"-","/",1,1)_".xml","\","/")
     
     } elseif ext="CLS"||(ext="PRJ")||(usertype&&(##class(%RoutineMgr).UserType(InternalName))) {
-        set nam=$translate(nam,"%")
+        set nam=$translate(nam,"%", ..PercentClassReplace())
         if '$$$GetSourceMapping(ext,"*","NoFolders"){
             set nam=$translate(nam,".","/")
         }

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -53,7 +53,7 @@ hr {
  set settings = ##class(SourceControl.Git.Settings).%New()
  set ^test = settings
  if $Data(%request.Data("gitsettings",1)) {
-    for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","gitUserName","gitUserEmail"{
+    for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace","gitUserName","gitUserEmail"{
         set $Property(settings,param) = $Get(%request.Data(param,1))
     }
     set i = 1
@@ -114,7 +114,6 @@ hr {
             <label for="privateKeyFile" class="col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Absolute path to your private SSH key file">SSH Private Key File</label>
             <div class="col-sm-7">
                 <input type="text" class="form-control" id="privateKeyFile" name="privateKeyFile" value='#(..EscapeHTML(settings.privateKeyFile))#' placeholder="C:\Users\ExampleUser\.ssh\id_rsa"/>
-                
             </div>
         </div>
 
@@ -125,6 +124,13 @@ hr {
                     <option value="SourceControl.Git.PullEventHandler.Default" #($Case(settings.pullEventClass,"SourceControl.Git.PullEventHandler.Default":"selected",:""))#>Default</option>
                     <option value="SourceControl.Git.PullEventHandler.PackageManager" #($Case(settings.pullEventClass,"SourceControl.Git.PullEventHandler.PackageManager":"selected",:""))#>PackageManager</option>
                 </select>
+            </div>
+        </div>
+
+        <div class="form-group row mb-3">
+            <label for="percentClassReplace" class="col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Character(s) to replace % with for percent classes">SSH Private Key File</label>
+            <div class="col-sm-7">
+                <input type="text" class="form-control" id="percentClassReplace" name="percentClassReplace" value='#(..EscapeHTML(settings.percentClassReplace))#' placeholder="_, __, <empty>, etc."/>
             </div>
         </div>
 


### PR DESCRIPTION
1. Configuring this is also possible from the Settings page. (The `Configure()` method picks up all properties of the class, so I didn't need to do anything special for that)
2. By default, "%" is replaced with an empty string (same as it is now, so it shouldn't break anything).

Closes #111 