### PR TITLE
Check for a URL prefix and add it

### DIFF
--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -16,7 +16,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
         } elseif $extract(pagePath,6,*) = "uncommitted" {
             set responseJSON = ..Uncommitted()
         } elseif $extract(pagePath,6,*) = "settings" {
-            set responseJSON = ..GetSettingsURL()
+            set responseJSON = ..GetSettingsURL(%request)
         } else {
             set %response.Status = ##class(%CSP.REST).#HTTP404NOTFOUND
             set responseJSON = {"error":("invalid URI: " _ pagePath)}
@@ -175,9 +175,19 @@ ClassMethod Uncommitted() As %SystemBase
     quit array
 }
 
-ClassMethod GetSettingsURL() As %SystemBase
+ClassMethod GetSettingsURL(%request As %CSP.Request) As %SystemBase
 {
-    quit {"url": ("/isc/studio/usertemplates/gitsourcecontrol/gitprojectsettings.csp?CSPSHARE=1&NSpace="_$namespace_"&Username="_$username)}
+   
+    set settingsURL = "/isc/studio/usertemplates/gitsourcecontrol/gitprojectsettings.csp?CSPSHARE=1&NSpace="_$namespace_"&Username="_$username
+    set appBasePath = "/isc/studio/usertemplates/gitsourcecontrol/"
+    
+    set locationOfAppPath = $LOCATE(%request.URL, appBasePath)
+
+    if (locationOfAppPath > 1) {
+        set beforeAppPath = $EXTRACT(%request.URL, 1, (locationOfAppPath-1))
+        set settingsURL = beforeAppPath_settingsURL
+    }
+    quit {"url": (settingsURL)}
 }
 
 }

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -175,18 +175,22 @@ ClassMethod Uncommitted() As %SystemBase
     quit array
 }
 
-ClassMethod GetSettingsURL(%request As %CSP.Request) As %SystemBase
+ClassMethod GetURLPrefix(%request As %CSP.Request, URL As %String) As %String
 {
-   
-    set settingsURL = "/isc/studio/usertemplates/gitsourcecontrol/gitprojectsettings.csp?CSPSHARE=1&NSpace="_$namespace_"&Username="_$username
     set appBasePath = "/isc/studio/usertemplates/gitsourcecontrol/"
-    
     set locationOfAppPath = $LOCATE(%request.URL, appBasePath)
 
     if (locationOfAppPath > 1) {
         set beforeAppPath = $EXTRACT(%request.URL, 1, (locationOfAppPath-1))
-        set settingsURL = beforeAppPath_settingsURL
+        set URL = beforeAppPath_URL
     }
+    quit URL
+}
+
+ClassMethod GetSettingsURL(%request As %CSP.Request) As %SystemBase
+{
+    set settingsURL = "/isc/studio/usertemplates/gitsourcecontrol/gitprojectsettings.csp?CSPSHARE=1&NSpace="_$namespace_"&Username="_$username
+    set settingsURL = ..GetURLPrefix(%request, settingsURL)
     quit {"url": (settingsURL)}
 }
 

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -53,19 +53,12 @@ hr {
  new $namespace
  set namespace = %request.Data("NSpace",1)
  set $namespace = namespace
-
- set webuiURL = "/isc/studio/usertemplates/gitsourcecontrol/webuidriver.csp/"_$namespace_"/?CSPSHARE=1"
- set appBasePath = "/isc/studio/usertemplates/gitsourcecontrol/"
-
- set locationOfAppPath = $LOCATE(%request.URL, appBasePath)
-
- if (locationOfAppPath > 1) {
-    set beforeAppPath = $EXTRACT(%request.URL, 1, (locationOfAppPath-1))
-    set webuiURL = beforeAppPath_webuiURL
- }
      
+ set webuiURL = "/isc/studio/usertemplates/gitsourcecontrol/webuidriver.csp/"_$namespace_"/?CSPSHARE=1"
+ set webuiURL = ##class(SourceControl.Git.WebUIDriver).GetURLPrefix(%request, webuiURL)
+ 
  set settings = ##class(SourceControl.Git.Settings).%New()
- set ^test = settings
+
  if $Data(%request.Data("gitsettings",1)) {
     for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace","gitUserName","gitUserEmail"{
         set $Property(settings,param) = $Get(%request.Data(param,1))

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -55,6 +55,15 @@ hr {
  set $namespace = namespace
 
  set webuiURL = "/isc/studio/usertemplates/gitsourcecontrol/webuidriver.csp/"_$namespace_"/?CSPSHARE=1"
+ set appBasePath = "/isc/studio/usertemplates/gitsourcecontrol/"
+
+ set locationOfAppPath = $LOCATE(%request.URL, appBasePath)
+
+ if (locationOfAppPath > 1) {
+    set beforeAppPath = $EXTRACT(%request.URL, 1, (locationOfAppPath-1))
+    set webuiURL = beforeAppPath_webuiURL
+ }
+     
  set settings = ##class(SourceControl.Git.Settings).%New()
  set ^test = settings
  if $Data(%request.Data("gitsettings",1)) {


### PR DESCRIPTION
Checks the request URL for a prefix and prepends it to the base URL if it exists.

Closes #121 