### PR TITLE
Minor bug fixes in utils

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1442,10 +1442,11 @@ ClassMethod Name(InternalName As %String) As %String
     for{
         set p=$order($$$SourceMapping(ext,p),-1) 
         quit:p=""  
-        if ($extract(nam,1,$length(p))=p) && ($data(^Sources(ext,p),found)){
+        if ($extract(nam,1,$length(p))=p) && ($data($$$SourceMapping(ext,p),found)){
             quit
         }
     }
+    
     if ($data(found)=0) && ($data($$$SourceMapping(ext,"*"),found)) && ('$$$GetSourceMapping(ext,"*","NoFolders")){
         set default=0
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -455,7 +455,7 @@ ClassMethod AddToSourceControl(InternalName As %String) As %Status
             set ec = $$$ADDSC(ec, sc)
         }
         for i=1:1:filenames{
-            set FileInternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filenames(i))
+            set FileInternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filenames(i), 0)
             set FileType = ##class(SourceControl.Git.Utils).Type(FileInternalName)
 
             continue:..NormalizeExtension(FileInternalName)=item


### PR DESCRIPTION
1. Setting `IgnorePercent` to 0 so that the `InternalName` of a percent class is not empty when adding it to source control. Closes #134 
2. Fixing an invalid global reference in the `Name()` method used to compute the `FullExternalName()` of files. We were getting incorrect paths for some files before. Closes #135 (could this also be the issue in #130?) 