### PR TITLE
Strip leading whitespace to type of change, filter out empty rows

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1358,12 +1358,12 @@ ClassMethod GitStatus(ByRef files, IncludeAllFiles = 0)
     set list = $listfromstring(lines, $char(0))
     set pointer = 0
     while $listnext(list, pointer, item) {
-        set operation = $extract(item, 1, 2)
+        set operation = $zstrip($extract(item, 1, 2), "<W")
         set externalName = $extract(item, 4, *)
         set internalName = ..NameToInternalName(externalName)
         if (internalName '= "") {
             set files(internalName) = $listbuild(operation, externalName)
-        } elseif IncludeAllFiles {
+        } elseif ((IncludeAllFiles) && (externalName '= "")) {
             set externalName = $TRANSLATE(externalName, "\", "/")
             set files($I(files)) = $listbuild(operation, externalName)
         } 


### PR DESCRIPTION
The `GitStatus()` method does not filter out cases where the external name is an empty string, and leaves in some leading whitespace in the type of change. I fixed these issues. 