### PR TITLE
Don't try to source control .ZPM docs

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1409,7 +1409,12 @@ ClassMethod Name(InternalName As %String) As %String
 
     if (nam="")||(ext=""){
         quit ""
-    } 
+    }
+
+    if (ext="ZPM") {
+        // Don't try to do anything with package file
+        quit ""
+    }
 
     // Any CSP items should be matched against the "/CSP/" mapping in ^Sources
     if InternalName["/" {
@@ -1608,3 +1613,4 @@ ClassMethod GetSourceControlInclude() As %String
 }
 
 }
+


### PR DESCRIPTION
This (a) doesn't work and (b) breaks the package manager context detection. (Discovered this running with latest git-source-control on a new instance using multiple package manager-enabled projects.)

Fixes #159 159