### PR TITLE
Add a check for login expiration when the user clicks on the settings nav button

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -631,6 +631,9 @@ webui.SideBarView = function(mainView, noEventHandlers) {
 
     self.goToSettingsPage = function() {
         $.get("api/settings", function (settingsURL){
+            if(settingsURL.indexOf("self.document.Login") != -1){
+                location.reload();
+            }
             var url = JSON.parse(settingsURL);
             window.location.replace(url.url);
         });

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -631,6 +631,9 @@ webui.SideBarView = function(mainView, noEventHandlers) {
 
     self.goToSettingsPage = function() {
         $.get("api/settings", function (settingsURL){
+            if(settingsURL.indexOf("self.document.Login") != -1){
+                location.reload();
+            }
             var url = JSON.parse(settingsURL);
             window.location.replace(url.url);
         });


### PR DESCRIPTION
We check for session expiry only when we do a git request. This meant that if the session expired and the user clicked on the settings button, the page would be unresponsive. 

I added a login expiration check to the response from `api/settings`. 

Closes #149 