### PR TITLE
Display diff of untracked files

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -1215,29 +1215,34 @@ webui.DiffView = function(sideBySide, hunkSelectionAllowed, parent, stashedCommi
                 right.webuiPrevScrollTop = 0;
                 right.webuiPrevScrollLeft = 0;
             }
-            self.gitFile = file;
-        }
-        if (self.gitCmd) {
-            var fullCmd = self.gitCmd;
-            if (self.complete) {
-                fullCmd += " --unified=999999999";
-            } else {
-                fullCmd += " --unified=" + self.context.toString();
-            }
-            if (self.ignoreWhitespace) {
-                fullCmd += " --ignore-all-space --ignore-blank-lines";
-            }
-            if (self.gitDiffOpts) {
-                fullCmd += " " + self.gitDiffOpts.join(" ")
-            }
-            if (self.gitFile) {
-                fullCmd += " -- " + self.gitFile;
-            }
-            webui.git(fullCmd, function(diff) {
-                self.refresh(diff);
+            webui.git("ls-files "+file, function(path){
+                self.gitFile = file;
+                self.noIndex = ""
+                if(path.length == 0 && file != undefined){
+                    self.gitFile = " /dev/null " + file;
+                    self.noIndex = " --no-index "
+                }
+                if (self.gitCmd) {
+                    var fullCmd = self.gitCmd;
+                    if (self.complete) {
+                        fullCmd += " --unified=999999999";
+                    } else {
+                        fullCmd += " --unified=" + self.context.toString();
+                    }
+                    if (self.ignoreWhitespace) {
+                        fullCmd += " --ignore-all-space --ignore-blank-lines";
+                    }
+                    if (self.gitDiffOpts) {
+                        fullCmd += " " + self.gitDiffOpts.join(" ")
+                    }
+                    if (self.gitFile) {
+                        fullCmd += self.noIndex + " -- " + self.gitFile;
+                    }
+                    webui.git(fullCmd, self.refresh, self.refresh, self.refresh);
+                } else {
+                    self.refresh("");
+                }
             });
-        } else {
-            self.refresh("");
         }
     };
 

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -1215,29 +1215,34 @@ webui.DiffView = function(sideBySide, hunkSelectionAllowed, parent, stashedCommi
                 right.webuiPrevScrollTop = 0;
                 right.webuiPrevScrollLeft = 0;
             }
-            self.gitFile = file;
-        }
-        if (self.gitCmd) {
-            var fullCmd = self.gitCmd;
-            if (self.complete) {
-                fullCmd += " --unified=999999999";
-            } else {
-                fullCmd += " --unified=" + self.context.toString();
-            }
-            if (self.ignoreWhitespace) {
-                fullCmd += " --ignore-all-space --ignore-blank-lines";
-            }
-            if (self.gitDiffOpts) {
-                fullCmd += " " + self.gitDiffOpts.join(" ")
-            }
-            if (self.gitFile) {
-                fullCmd += " -- " + self.gitFile;
-            }
-            webui.git(fullCmd, function(diff) {
-                self.refresh(diff);
+            webui.git("ls-files "+file, function(path){
+                self.gitFile = file;
+                self.noIndex = ""
+                if(path.length == 0 && file != undefined){
+                    self.gitFile = " /dev/null " + file;
+                    self.noIndex = " --no-index "
+                }
+                if (self.gitCmd) {
+                    var fullCmd = self.gitCmd;
+                    if (self.complete) {
+                        fullCmd += " --unified=999999999";
+                    } else {
+                        fullCmd += " --unified=" + self.context.toString();
+                    }
+                    if (self.ignoreWhitespace) {
+                        fullCmd += " --ignore-all-space --ignore-blank-lines";
+                    }
+                    if (self.gitDiffOpts) {
+                        fullCmd += " " + self.gitDiffOpts.join(" ")
+                    }
+                    if (self.gitFile) {
+                        fullCmd += self.noIndex + " -- " + self.gitFile;
+                    }
+                    webui.git(fullCmd, self.refresh, self.refresh, self.refresh);
+                } else {
+                    self.refresh("");
+                }
             });
-        } else {
-            self.refresh("");
         }
     };
 


### PR DESCRIPTION
The workspace now displays a diff of untracked files as well. We need to jump through some hoops to get the diff of untracked files because of some weird design decisions in git. 

Closes #142 