### PR TITLE
In RefreshUncommitted(), remove item from uncommitted queue if there is no change according to git

### DIFF
--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -1,3 +1,5 @@
+Include SourceControl.Git
+
 Class SourceControl.Git.Change Extends %Studio.SourceControl.Change
 {
 
@@ -79,13 +81,21 @@ ClassMethod IsUncommitted(Filename, ByRef ID) As %Boolean
 /// Goes through Uncommitted queue and removes any items of action 'edit' or 'add' which are ReadOnly or non-existent on the filesystem
 ClassMethod RefreshUncommitted(Display = 1, IncludeRevert = 0) As %Status
 {
+    // files from the uncommitted queue
     set sc=..ListUncommitted(.tFileList,IncludeRevert,0)
     if $$$ISERR(sc) quit sc
+
+    // files from git status
+    do ##class(Utils).GitStatus(.gitFiles)
+
     set filename="", filename=$order(tFileList(filename),1,action)
-    while (filename'="") {
+    while (filename'="") {        
         set examine=$select(action="add":1,action="edit":1,IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
-        if ('##class(%File).Exists(filename)) {
+
+        set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
+
+        if (('##class(%File).Exists(filename)) || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && ($data($$$TrackedItems(InternalName)))))  {
             set sc=..RemoveUncommitted(filename,Display,0,0)
             if $$$ISERR(sc) set filename="" continue
         }

--- a/inc/SourceControl/Git.inc
+++ b/inc/SourceControl/Git.inc
@@ -3,4 +3,4 @@ ROUTINE SourceControl.Git [Type=INC]
 #def1arg SourceMapping(%arg) ^SYS("SourceControl","Git","settings","mappings",%arg)
 #def1arg GetSourceMapping(%arg) $Get($$$SourceMapping(%arg))
 #def1arg NewLineIfNonEmptyStream(%arg) if %arg.Size > 0 write !
-
+#def1arg TrackedItems(%arg) ^SYS("SourceControl","Git","items", %arg)


### PR DESCRIPTION
If you do commits from the WebUI, the Uncommitted queue keeps accumulating records of changed files which don't get cleared out. This way, there is a way to clear out old changes that have been committed but their records haven't been removed. 

Ideally we want to remove the record when the change is committed though. 

Closes #155 