### PR TITLE
Remove deleted file from global

### DIFF
--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -1,3 +1,5 @@
+Include SourceControl.Git
+
 Class SourceControl.Git.Change Extends %Studio.SourceControl.Change
 {
 
@@ -79,13 +81,21 @@ ClassMethod IsUncommitted(Filename, ByRef ID) As %Boolean
 /// Goes through Uncommitted queue and removes any items of action 'edit' or 'add' which are ReadOnly or non-existent on the filesystem
 ClassMethod RefreshUncommitted(Display = 1, IncludeRevert = 0) As %Status
 {
+    // files from the uncommitted queue
     set sc=..ListUncommitted(.tFileList,IncludeRevert,0)
     if $$$ISERR(sc) quit sc
+
+    // files from git status
+    do ##class(Utils).GitStatus(.gitFiles)
+
     set filename="", filename=$order(tFileList(filename),1,action)
-    while (filename'="") {
+    while (filename'="") {        
         set examine=$select(action="add":1,action="edit":1,IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
-        if ('##class(%File).Exists(filename)) {
+
+        set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
+
+        if (('##class(%File).Exists(filename)) || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && ($data($$$TrackedItems(InternalName)))))  {
             set sc=..RemoveUncommitted(filename,Display,0,0)
             if $$$ISERR(sc) set filename="" continue
         }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1145,6 +1145,7 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
             
             if deleted && ec {
                 do ..RemoveRoutineTSH(item)
+                kill $$$TrackedItems(..NormalizeExtension(item))
                 write !, item, " was deleted"
             } else {
                 if +$system.Status.GetErrorCodes(ec) '= $$$ClassDoesNotExist {

--- a/inc/SourceControl/Git.inc
+++ b/inc/SourceControl/Git.inc
@@ -3,4 +3,4 @@ ROUTINE SourceControl.Git [Type=INC]
 #def1arg SourceMapping(%arg) ^SYS("SourceControl","Git","settings","mappings",%arg)
 #def1arg GetSourceMapping(%arg) $Get($$$SourceMapping(%arg))
 #def1arg NewLineIfNonEmptyStream(%arg) if %arg.Size > 0 write !
-
+#def1arg TrackedItems(%arg) ^SYS("SourceControl","Git","items", %arg)


### PR DESCRIPTION
We also remove the file from the tracking global if we find that it was deleted while doing an import. Closes #152 