### PR TITLE
Route directly to the settings page instead of going back to the WebUI

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -63,6 +63,11 @@ webui.settingsIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height=
                         '<path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>'+
                     '</svg>'
 
+webui.settingsURL = "";
+$.get("api/settings", function(settingsURL){
+    var url = JSON.parse(settingsURL);
+    webui.settingsURL = url.url;
+});
 
 webui.showSuccess = function(message) {
     var messageBox = $("#message-box");
@@ -630,13 +635,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
     }
 
     self.goToSettingsPage = function() {
-        $.get("api/settings", function (settingsURL){
-            if(settingsURL.indexOf("self.document.Login") != -1){
-                location.reload();
-            }
-            var url = JSON.parse(settingsURL);
-            window.location.replace(url.url);
-        });
+        window.location.replace(webui.settingsURL);
     }
 
     self.fetchSection = function(section, title, id, gitCommand) {
@@ -2483,8 +2482,8 @@ function MainUi() {
 var MainUIObject;
 
 $(document).ready(function () {
-   MainUIObject = new MainUi();
-   $('[data-toggle="tooltip"]').tooltip();
+    MainUIObject = new MainUi();
+    $('[data-toggle="tooltip"]').tooltip();
 });
 
 function updateSideBar () {

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -63,6 +63,11 @@ webui.settingsIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height=
                         '<path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>'+
                     '</svg>'
 
+webui.settingsURL = "";
+$.get("api/settings", function(settingsURL){
+    var url = JSON.parse(settingsURL);
+    webui.settingsURL = url.url;
+});
 
 webui.showSuccess = function(message) {
     var messageBox = $("#message-box");
@@ -630,13 +635,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
     }
 
     self.goToSettingsPage = function() {
-        $.get("api/settings", function (settingsURL){
-            if(settingsURL.indexOf("self.document.Login") != -1){
-                location.reload();
-            }
-            var url = JSON.parse(settingsURL);
-            window.location.replace(url.url);
-        });
+        window.location.replace(webui.settingsURL);
     }
 
     self.fetchSection = function(section, title, id, gitCommand) {
@@ -2483,8 +2482,8 @@ function MainUi() {
 var MainUIObject;
 
 $(document).ready(function () {
-   MainUIObject = new MainUi();
-   $('[data-toggle="tooltip"]').tooltip();
+    MainUIObject = new MainUi();
+    $('[data-toggle="tooltip"]').tooltip();
 });
 
 function updateSideBar () {


### PR DESCRIPTION
After CSP session expires and the user clicks the settings button in the WebUI, we go to the login screen and then route to the settings page directly instead of reloading the WebUI.