### PR TITLE
Fix workspace operations for filenames with spaces

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -2090,7 +2090,13 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         } else {
                             model = line;
                         }
-                        var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        var isForCurrentUser;
+                        if(model.indexOf(" ") > -1){
+                            model = model.substring(1, model.length-1)
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        } else {
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        }
                         var cssClass = isForCurrentUser ? 'list-group-item available' : 'list-group-item unavailable';
 
                         if(isForCurrentUser){

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -405,7 +405,12 @@ webui.SideBarView = function(mainView, noEventHandlers) {
                             } else {
                                 model = line;
                             }
-                            var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            var isForCurrentUser;
+                            if(model.indexOf(" ") > -1){
+                                isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
+                            } else {
+                                isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            }
                             if(!isForCurrentUser) {
                                 flag = 1;
                             }
@@ -478,7 +483,12 @@ webui.SideBarView = function(mainView, noEventHandlers) {
                         } else {
                             model = line;
                         }
-                        var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        var isForCurrentUser;
+                        if(model.indexOf(" ") > -1){
+                            isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
+                        } else {
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        }
                         if(!isForCurrentUser) {
                             flag = 1;
                         }
@@ -2092,8 +2102,7 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         }
                         var isForCurrentUser;
                         if(model.indexOf(" ") > -1){
-                            model = model.substring(1, model.length-1)
-                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
                         } else {
                             isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
                         }
@@ -2265,7 +2274,7 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
             var excluded = excluding != undefined && excluding.indexOf(child.status) != -1;
             if ($(child).hasClass("active") && ($(child).hasClass("available")^onlyUnavailable) && included && !excluded) {   
                 if(stringifyFilenames)
-                    files += '"' + (child.model) + '" ';
+                    files += ((child.model) + ' ');
                 else
                     files.push(child);
             }

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -2090,7 +2090,13 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         } else {
                             model = line;
                         }
-                        var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        var isForCurrentUser;
+                        if(model.indexOf(" ") > -1){
+                            model = model.substring(1, model.length-1)
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        } else {
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        }
                         var cssClass = isForCurrentUser ? 'list-group-item available' : 'list-group-item unavailable';
 
                         if(isForCurrentUser){

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -405,7 +405,12 @@ webui.SideBarView = function(mainView, noEventHandlers) {
                             } else {
                                 model = line;
                             }
-                            var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            var isForCurrentUser;
+                            if(model.indexOf(" ") > -1){
+                                isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
+                            } else {
+                                isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            }
                             if(!isForCurrentUser) {
                                 flag = 1;
                             }
@@ -478,7 +483,12 @@ webui.SideBarView = function(mainView, noEventHandlers) {
                         } else {
                             model = line;
                         }
-                        var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        var isForCurrentUser;
+                        if(model.indexOf(" ") > -1){
+                            isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
+                        } else {
+                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                        }
                         if(!isForCurrentUser) {
                             flag = 1;
                         }
@@ -2092,8 +2102,7 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         }
                         var isForCurrentUser;
                         if(model.indexOf(" ") > -1){
-                            model = model.substring(1, model.length-1)
-                            isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
+                            isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
                         } else {
                             isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
                         }
@@ -2265,7 +2274,7 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
             var excluded = excluding != undefined && excluding.indexOf(child.status) != -1;
             if ($(child).hasClass("active") && ($(child).hasClass("available")^onlyUnavailable) && included && !excluded) {   
                 if(stringifyFilenames)
-                    files += '"' + (child.model) + '" ';
+                    files += ((child.model) + ' ');
                 else
                     files.push(child);
             }


### PR DESCRIPTION
1. Fixed the check for whether the current user edited a certain file. It failed with filenames which had spaces in them because those strings were quoted and the string used for comparison was not.
2. Fixed the way we get a list of files, upon which the selected operation occurs. 

Closes #178 