### PR TITLE
Refresh uncommitted

### DIFF
--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -79,7 +79,7 @@ ClassMethod IsUncommitted(Filename, ByRef ID) As %Boolean
 }
 
 /// Goes through Uncommitted queue and removes any items of action 'edit' or 'add' which are ReadOnly or non-existent on the filesystem
-ClassMethod RefreshUncommitted(Display = 1, IncludeRevert = 0) As %Status
+ClassMethod RefreshUncommitted(Display = 0, IncludeRevert = 0) As %Status
 {
     // files from the uncommitted queue
     set sc=..ListUncommitted(.tFileList,IncludeRevert,0)
@@ -88,21 +88,42 @@ ClassMethod RefreshUncommitted(Display = 1, IncludeRevert = 0) As %Status
     // files from git status
     do ##class(Utils).GitStatus(.gitFiles)
 
+    // Remove entries in the uncommitted queue that don't correspond to changes as tracked by git
     set filename="", filename=$order(tFileList(filename),1,action)
-    while (filename'="") {        
-        set examine=$select(action="add":1,action="edit":1,IncludeRevert&&(action="revert"):1,1:0)
+    while (filename'="") {       
+        set examine=$select(action="add":1,action="edit":1,action="delete":1, IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
 
         set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
 
-        if (('##class(%File).Exists(filename)) || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && ($data($$$TrackedItems(InternalName)))))  {
+        if (('##class(%File).Exists(filename)) || (InternalName = "") || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && 
+            (($data($$$TrackedItems(InternalName))) || ##class(SourceControl.Git.Utils).NormalizeExtension($data($$$TrackedItems(InternalName))))))  {
             set sc=..RemoveUncommitted(filename,Display,0,0)
             if $$$ISERR(sc) set filename="" continue
         }
         set filename=$order(tFileList(filename),1,action)
     }
+
+    // Add missing records to the uncommitted queue that correspond to changes as tracked by git
+    set filename="", filename=$order(gitFiles(filename),1,details)
+    while (filename'="") {  
+        set InternalName = filename
+        set ExternalName = ##class(%File).NormalizeFilename(##class(SourceControl.Git.Utils).TempFolder()_$list(details,2))
+        set changeType = $list(details,1)
+
+        set action = $select(changeType="A":"add", 
+                             changeType="M":"edit",
+                             changeType="D":"delete",
+                             changeType="U":"add",
+                             1:"add")
+
+        if ((##class(%File).Exists(ExternalName)) && ('$ISVALIDNUM(InternalName)) && ('..IsUncommitted(ExternalName)) && ($data($$$TrackedItems(InternalName))))  {
+            set sc=..SetUncommitted(ExternalName, action, InternalName, $USERNAME, "", 1, "", "", 0)
+            if $$$ISERR(sc) w sc set filename="" continue
+        }
+        set filename=$order(gitFiles(filename),1,details)
+    }
     quit sc
 }
 
 }
-

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -289,6 +289,7 @@ Method GetStatus(InternalName As %String, ByRef IsInSourceControl As %Boolean, B
     if '$$$FileExists(filename) {
         set IsCheckedOut=0
     }
+    do ##class(SourceControl.Git.Change).RefreshUncommitted()
     do ##class(SourceControl.Git.Utils).GitStatus(.files)
     if $get(files(InternalName)) '= "" {
         ///it's in source control, checked out, and should be locked to editing by other users

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -39,6 +39,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
                 if $piece(pagePath,"/",3) = "cat-file" {
                     set file = $piece(pagePath,"/",4,*)
                     do ##class(SourceControl.Git.Utils).RunGitCommand("-c",,.%data,"color.ui=false","cat-file","-p",file)
+                    do ##class(SourceControl.Git.Change).RefreshUncommitted()
                     set handled = 1
                 }
             } elseif (pathStart = "hostname") {
@@ -133,6 +134,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
                 do %data.WriteLine("Git-Stderr-Length: " _ (errStream.Size + nLines))
                 do %data.Write("Git-Return-Code: " _ returnCode) // No ending newline expected
                 do %data.Rewind()
+                do ##class(SourceControl.Git.Change).RefreshUncommitted()
                 set handled = 1
             }
         }
@@ -151,7 +153,8 @@ ClassMethod UserInfo() As %SystemBase
 ClassMethod Uncommitted() As %SystemBase
 {
     // Stub
-    do ##class(Utils).GitStatus(.files, 1)
+    do ##class(SourceControl.Git.Change).RefreshUncommitted()
+    do ##class(SourceControl.Git.Utils).GitStatus(.files, 1)
     set output = ""
     set key = ""
 


### PR DESCRIPTION
Updated `RefreshUncommitted()` to also add record to the uncommitted queue when appropriate. Also called it in a few places to make sure the uncommitted queue is always up to date. 