### PR TITLE
Changed the way we match mappings in NameToInternalName, modified and added new testcases

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1648,14 +1648,15 @@ ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1, V
         }
         if $data(ext)=0 {
             if (Verbose){
+                write !
                 if (bestScore#100 = 0){
-                    write "No mapping with a matching coverage found for file "_name, !
+                    write !, "No mapping with a matching coverage found for file "_name
                 }
                 if (((bestScore\10)#10) = 0){
-                    write "No mapping with a matching path found for file "_name, !
+                    write !, "No mapping with a matching path found for file "_name
                 }
-                if (((bestScore\100)#10) = 0){
-                    write "No mapping with a matching extension found for file "_name, !
+                if ((bestScore\100) = 0){
+                    write !, "No mapping with a matching extension found for file "_name
                 }
             }
             quit ""

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -451,7 +451,7 @@ ClassMethod AddToSourceControl(InternalName As %String) As %Status
             set ec = $$$ADDSC(ec, sc)
         }
         for i=1:1:filenames{
-            set FileInternalName = ##class(SourceControl.Git.Utils).NormalizeExtension(##class(SourceControl.Git.Utils).NameToInternalName(filenames(i), 0))
+            set FileInternalName = ##class(SourceControl.Git.Utils).NormalizeExtension(##class(SourceControl.Git.Utils).NameToInternalName(filenames(i), 0,,1))
             set FileType = ##class(SourceControl.Git.Utils).Type(FileInternalName)
 
             set @..#Storage@("items", FileInternalName) = ""
@@ -1649,13 +1649,13 @@ ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1, V
         if $data(ext)=0 {
             if (Verbose){
                 if (bestScore#100 = 0){
-                    w "No mapping with a matching coverage found for file "_name, !
+                    write "No mapping with a matching coverage found for file "_name, !
                 }
                 if (((bestScore\10)#10) = 0){
-                    w "No mapping with a matching path found for file "_name, !
+                    write "No mapping with a matching path found for file "_name, !
                 }
                 if (((bestScore\100)#10) = 0){
-                    w "No mapping with a matching extension found for file "_name, !
+                    write "No mapping with a matching extension found for file "_name, !
                 }
             }
             quit ""

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1530,7 +1530,7 @@ ClassMethod Name(InternalName As %String, ByRef MappingExists As %Boolean) As %S
 	NameToInternalName(name): given a Unix-style slash path relative to repo root, 
 	returns the internal name for that file (e.g., cls/SourceControl/Git/Utils.cls -> SourceControl.Git.Utils.CLS)
 */
-ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1) As %String
+ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1, Verbose As %Boolean = 0) As %String
 {
     set InternalName=""
     set Deleted = 0
@@ -1556,21 +1556,73 @@ ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1) A
     if (InternalName="") {
         set name=$extract(Name,$length($$$SourceRoot)+1,*)
         set name=$replace(name,"\","/")	// standardize slash direction
-        //file is in a subdirectory under the ^Sources root
+
         set nam = name
         
-        set queryary=$query($$$SourceMapping(""),-1,dir), mappingsSubscript = $qsubscript(queryary,4), subscript=$qsubscript(queryary,5)
+        set queryary=$query($$$SourceMapping(""),-1,dir), mappingsSubscript = $qsubscript(queryary,4)
+        set subscript=$qsubscript(queryary,5), coverage = $qsubscript(queryary, 6)
+        set bestMatch = $lb(subscript, coverage, dir)
+        set bestScore = 0
+        set currScore = 0
         while (queryary'="")&&(mappingsSubscript="mappings") {
-            if (dir["/")&&(dir=$extract(name, 1, $length(dir))) {
-                set ext=subscript
-                set nam = $extract(name, $length(dir)+1, *)
-                quit
+            set nam = $extract(name, $length(dir)+1, *)
+            if ($zconvert(subscript, "U") = $zconvert($piece(name, ".", *), "U")){
+                set extScore = 1
+            } else {
+                set extScore = 0
             }
+
+            if ((dir["/")&&(dir=$extract(name, 1, $length(dir)))){
+                set pathScore = 1
+            } else {
+                set pathScore = 0  
+            }
+
+            if (coverage = "*"){
+                set covScore = 1
+            } elseif ($extract($translate(nam, "/", "."), 1, ($length(coverage)+1)) = (coverage_".")) {
+                set covScore = 2
+            } else {
+                set covScore = 0
+            }
+
+            set currScore = (extScore*100) + (pathScore*10) + covScore
+
+            if (currScore > bestScore){
+                set bestScore = currScore
+                set bestMatch = $lb(subscript, coverage, dir)
+            } elseif ((currScore = bestScore) && currScore>=111) {
+                // There are 4 cases here - 
+                // 1. Coverage is more specific in one and Path is the same.
+                // 2. Path is more specific in one and Coverage is the same.
+                // 3. Coverage is more specific in one while Path is more specific in the other.
+                // 4. Both are more specific in one. 
+                // Coverage has higher priority.
+                // Note that a file extension has no notion of specificity. 
+                // Specificity, for both Coverage and Path, is defined as being directly proportional to the length of the string.
+
+                set covSpecific = 0, pathSpecific = 0
+                
+                if ($length(coverage) > $length($listget(bestMatch, 2))){
+                    set bestMatch = $lb(subscript, coverage, dir)
+                } elseif ($length(coverage) = $length($listget(bestMatch, 2))){
+                    if ($length(dir) > $length($listget(bestMatch, 3))){
+                        set bestMatch = $lb(subscript, coverage, dir)
+                    }
+                }
+            }
+
             set queryary=$query(@queryary,-1,dir)
             if (queryary="") {
                 quit
             }
-            set mappingsSubscript = $qsubscript(queryary,4), subscript=$qsubscript(queryary,5)
+            set mappingsSubscript = $qsubscript(queryary,4), subscript=$qsubscript(queryary,5), coverage = $qsubscript(queryary, 6)
+        }
+
+        if (bestScore >= 111){
+            set ext = $listget(bestMatch,1)
+            set dir = $listget(bestMatch, 3)
+            set nam = $extract(name, $length(dir)+1, *)
         }
 
         if ($get(ext)="/CSP/") {
@@ -1595,6 +1647,17 @@ ClassMethod NameToInternalName(Name, IgnorePercent = 1, IgnoreNonexistent = 1) A
             }
         }
         if $data(ext)=0 {
+            if (Verbose){
+                if (bestScore#100 = 0){
+                    w "No mapping with a matching coverage found for file "_name, !
+                }
+                if (((bestScore\10)#10) = 0){
+                    w "No mapping with a matching path found for file "_name, !
+                }
+                if (((bestScore\100)#10) = 0){
+                    w "No mapping with a matching extension found for file "_name, !
+                }
+            }
             quit ""
         }
         set fileExt=$zconvert(ext,"L")

--- a/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
+++ b/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
@@ -12,47 +12,66 @@ Property OldNamespaceTemp As %String;
 Method TestRegularClassNames()
 {
 	// Regular class that exists
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\SourceControl\Git\Utils.cls"),"SourceControl.Git.Utils.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\SourceControl\Git\Utils.cls"),"SourceControl.Git.Utils.CLS")
 	// Regular class that doesn't exist and we ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls"),"")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls"),"")
 	// Regular class that doesn't exist and we don't ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls", 1, 0),"SourceControl.Git.DoesNotExist.CLS")
-	do $$$AssertEquals(##class(Utils).NameToInternalName("test\UnitTest\Git\DoesNotExist.cls", 1, 0),"UnitTest.Git.DoesNotExist.CLS")
-	do $$$AssertEquals(##class(Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.cls", 1, 0),"UnitTest.Foo.Git.DoesNotExist.CLS")
-	do $$$AssertEquals(##class(Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.foo", 1, 0),"UnitTest.Foo.Git.DoesNotExist.FOO")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls", 1, 0),"SourceControl.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("test\UnitTest\Git\DoesNotExist.cls", 1, 0),"UnitTest.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.cls", 1, 0),"UnitTest.Foo.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.foo", 1, 0),"UnitTest.Foo.Git.DoesNotExist.FOO")
 }
 
 Method TestPercentClassNames()
 {
 	// % class that exists but we ignore % classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\Base.cls"),"")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\Base.cls"),"")
 	// % class that exists and we don't ignore % classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\Base.cls", 0),"%Studio.Extension.Base.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\Base.cls", 0),"%Studio.Extension.Base.CLS")
 	// % class that doesn't exist and we ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\DoesNotExist.cls", 0),"")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\DoesNotExist.cls", 0),"")
 	// % class that doesn't exist and we don't ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\DoesNotExist.cls", 0, 0),"%Studio.Extension.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("cls\"_##class(SourceControl.Git.Utils).PercentClassReplace()_"Studio\Extension\DoesNotExist.cls", 0, 0),"%Studio.Extension.DoesNotExist.CLS")
 }
 
 Method TestAbstractDocumentClassNames()
 {
 	// %Studio.AbstractDocument type that exists
 	do ##class(%RoutineMgr).Delete("test2.pivot.DFI")
-	do $$$AssertEquals(##class(Utils).NameToInternalName("test\_resources\dfi\test2.pivot.dfi"),"")
-	do $$$AssertStatusOK(##class(Utils).ImportItem("test2.pivot.DFI",1))
-	do $$$AssertEquals(##class(Utils).NameToInternalName("test\_resources\dfi\test2.pivot.dfi"),"test2.pivot.DFI")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("test\_resources\dfi\test2.pivot.dfi"),"")
+	do $$$AssertStatusOK(##class(SourceControl.Git.Utils).ImportItem("test2.pivot.DFI",1))
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("test\_resources\dfi\test2.pivot.dfi"),"test2.pivot.DFI")
 	// %Studio.AbstractDocument type that does not exist and we ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("test\_resources\dfi\DoesNotExist.dfi"),"")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("test\_resources\dfi\DoesNotExist.dfi"),"")
 	//  %Studio.AbstractDocument type that doesn't exist and we don't ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("test\_resources\dfi\DoesNotExist.dfi", 1, 0),"DoesNotExist.DFI")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("test\_resources\dfi\DoesNotExist.dfi", 1, 0),"DoesNotExist.DFI")
 }
 
 Method TestStaticFileNames()
 {
 	// Static file that shouldn't be on the server
-	do $$$AssertEquals(##class(Utils).NameToInternalName("git-webui\src\js\git-webui.js"),"")
-	// Static file that shouldn't be on the server but we don't ignore non-existent classes
-	do $$$AssertEquals(##class(Utils).NameToInternalName("git-webui\src\js\git-webui.js", 1, 0),"")
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("git-webui\src\js\git-webui.js"),"")
+	// Static file that shouldn't be on the server but we don't ignore non-existent classes (000 composite score)
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("git-webui\src\js\git-webui.js", 1, 0, 1),"")
+}
+
+Method TestNegative()
+{
+	// Based on composite scores
+	 
+	// 000 is covered in TestStaticFileNames()
+	// 001 and 002
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("barq\MyBarFile1.barq", 1, 0, 1),"")
+	// 010
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("bar\NotMyBarFile1.barq", 1, 0, 1),"")
+	// 011 and 012
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("bar\MyBarFile1.barq", 1, 0, 1),"")
+	// 100
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("barq\NotMyBarFile1.bar", 1, 0, 1),"")
+	// 101 and 102
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("barq\MyBarFile1.bar", 1, 0, 1),"")
+	// 110
+	do $$$AssertEquals(##class(SourceControl.Git.Utils).NameToInternalName("bar\NotMyBarFile1.bar", 1, 0, 1),"")
 }
 
 Method OnBeforeAllTests() As %Status
@@ -67,6 +86,7 @@ Method OnBeforeAllTests() As %Status
 	set $$$SourceMapping("CLS", "UnitTest") = "test/"
 	set $$$SourceMapping("CLS", "UnitTest.Foo") = "foo/"
 	set $$$SourceMapping("FOO", "*") = "foo/"
+	set $$$SourceMapping("BAR", "MyBarFile") = "bar/"
 	set $$$SourceMapping("DFI", "*", "NoFolders") = 1
 	set $$$SourceMapping("DFI", "*") = "test/_resources/dfi/"
 	quit $$$OK

--- a/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
+++ b/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
@@ -17,6 +17,9 @@ Method TestRegularClassNames()
 	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls"),"")
 	// Regular class that doesn't exist and we don't ignore non-existent classes
 	do $$$AssertEquals(##class(Utils).NameToInternalName("cls\SourceControl\Git\DoesNotExist.cls", 1, 0),"SourceControl.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(Utils).NameToInternalName("test\UnitTest\Git\DoesNotExist.cls", 1, 0),"UnitTest.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.cls", 1, 0),"UnitTest.Foo.Git.DoesNotExist.CLS")
+	do $$$AssertEquals(##class(Utils).NameToInternalName("foo\UnitTest\Foo\Git\DoesNotExist.foo", 1, 0),"UnitTest.Foo.Git.DoesNotExist.FOO")
 }
 
 Method TestPercentClassNames()
@@ -61,6 +64,9 @@ Method OnBeforeAllTests() As %Status
 	merge ..Mappings = @##class(SourceControl.Git.Utils).MappingsNode()
 	kill @##class(SourceControl.Git.Utils).MappingsNode()
 	set $$$SourceMapping("CLS", "*") = "cls/"
+	set $$$SourceMapping("CLS", "UnitTest") = "test/"
+	set $$$SourceMapping("CLS", "UnitTest.Foo") = "foo/"
+	set $$$SourceMapping("FOO", "*") = "foo/"
 	set $$$SourceMapping("DFI", "*", "NoFolders") = 1
 	set $$$SourceMapping("DFI", "*") = "test/_resources/dfi/"
 	quit $$$OK
@@ -77,4 +83,3 @@ Method %OnClose() As %Status
 }
 
 }
-


### PR DESCRIPTION
Closes #198.

The new mapping match method is more robust than the previous one. It is described in detail below. We also provide more detailed explanations on what went wrong when adding a file to source control. 
<br/>

## Matching mappings

For every mapping we have we can compute a composite score that describes how strong the match is. There are 3 main factors that need to be considered here.

### Path matches

Here we have to check if the path in the `ExternalName` matches the path specified by the mapping.

1. Not a match
2. Path match

### Extension matches

We confirm that the extension of the file in the `ExternalName` is the same as the extension in the mapping.

1. Not a match
2. Extension match

Note: There is a possibility that the extension of some files might be different from the one in the mapping. e.g. `.dfi` files might be exported out as XML files. If the extension does the export, then we export the `.dfi` file as-is, so we don't have to worry about this edge case. However, we also do a Load() of the file to try and get the `InternalName` directly and that should catch cases like the one in the example.

### Coverage matches

1. Not a match
2. "\*" match
3. Specific package match

### Composite scores

Based on the match types above we have 12 possible composite scores.

![image](https://user-images.githubusercontent.com/91484958/168622118-ad86be63-1049-436c-9ccc-f730f90da501.png)

### Tie-breaker rules

If we need a tie-breaker, we consider a specfic match to be a better match. Specificity, for both Coverage and Path, is defined as being directly proportional to the length of the string. Thus, there are 4 possible scenarios: 

1. Coverage is more specific in one and Path is the same.
2. Path is more specific in one and Coverage is the same.
3. Coverage is more specific in one while Path is more specific in the other.
4. Both are more specific in one. 

We give coverage a higher priority. Note that a file extension has no notion of specificity. 

### Algorithm

We iterate through all the configured mappings and compute a composite score for each with respect to the `Name` function parameter. We keep track of the best match found up till that point and update it as we get a better match. In case, we get a mapping with the same composite score as the best one yet, we use the tie-breaker rules to resolve the best match. If the best match has a score >= 111, we have found a valid match. Otherwise we have not and provide explanations for what might have gone wrong. 