### PR TITLE
Various fixes for import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.6] - 2022-12-06
+## [2.0.6] - Unreleased
 
 ### Added
 - Support for Caché/Ensemble 2016.2.3, 2017.1.2, 2017.2.1, 2018.1.0 and later. (Treated as patch version bump because no compatibility impact for existing users.)
+
+### Fixed
+- "Import All" will properly recognize new files
+- "Import All" and "Export All" apply only to the current package manager context and disregard items outside that context
 
 ### Changed
 - Various minor things under the hood to support use without the package manager and/or on older platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - "Import All" will properly recognize new files
 - "Import All" and "Export All" apply only to the current package manager context and disregard items outside that context
+- "Import All" treats "Other" document types (DFI, LUT, etc.) properly
 
 ### Changed
 - Various minor things under the hood to support use without the package manager and/or on older platforms

--- a/cls/SourceControl/Git/PackageManagerContext.cls
+++ b/cls/SourceControl/Git/PackageManagerContext.cls
@@ -16,6 +16,7 @@ Property ResourceReference As %RegisteredObject [ InitialExpression = {$$$NULLOR
 
 Method InternalNameSet(InternalName As %String = "") As %Status
 {
+    set InternalName = ##class(SourceControl.Git.Utils).NormalizeInternalName(InternalName)
     if (InternalName '= i%InternalName) {
         set i%InternalName = InternalName
         if '$$$comClassDefined("%ZPM.PackageManager.Developer.Extension.Utils") {
@@ -24,7 +25,7 @@ Method InternalNameSet(InternalName As %String = "") As %Status
         set ..Package = ##class(%ZPM.PackageManager.Developer.Extension.Utils).FindHomeModule(InternalName,,.resourceReference)
         set ..ResourceReference = resourceReference
         set ..IsInGitEnabledPackage = $isobject(..Package) && ##class(%Library.File).DirectoryExists(##class(%Library.File).NormalizeFilename(".git",..Package.Root))
-        set ..IsInDefaultPackage = $isobject(..Package) && (##class(%Library.File).NormalizeDirectory(..Package.Root) = ##class(%Library.File).NormalizeDirectory(##class(SourceControl.Git.Utils).TempFolder()))
+        set ..IsInDefaultPackage = $isobject(..Package) && (##class(%Library.File).NormalizeDirectory(..Package.Root) = ##class(%Library.File).NormalizeDirectory(##class(SourceControl.Git.Utils).DefaultTempFolder()))
     }
     quit $$$OK
 }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1094,8 +1094,17 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
             set mappedFilePath = ##class(%File).NormalizeFilename(mappedRelativePath, ..TempFolder())
             
             if (##class(%File).DirectoryExists(mappedFilePath)){
-                set res = $system.OBJ.ImportDir(mappedFilePath,,"-d",.err,1, .tempItemList, $$$DoNotLoad)
-                merge itemList = tempItemList
+                if ##class(%Library.RoutineMgr).UserType("foo."_mappingFileType) {
+                    set fileSpec = "*."_$zcvt(mappingFileType,"L")_";*."_$zconvert(mappingFileType,"U")
+                    set files = ##class(%Library.File).FileSetFunc(mappedFilePath,fileSpec)
+                    while files.%Next() {
+                        // Assumes flat file structure
+                        set itemList(files.ItemName) = ""
+                    }
+                } else {
+                    set res = $system.OBJ.ImportDir(mappedFilePath,,"-d",.err,1, .tempItemList, $$$DoNotLoad)
+                    merge itemList = tempItemList
+                }
             }
 
             set mappingCoverage = $order($$$SourceMapping(mappingFileType, mappingCoverage))
@@ -1148,7 +1157,11 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
         quit:internalName=""
         set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(internalName)
         continue:context.Package'=refPackage
-        #dim sc as %Status = ..ImportItem(internalName, force)
+        if ..IsInSourceControl(internalName) {
+            set sc = ..ImportItem(internalName, force)            
+        } else {
+            set sc = ..AddToServerSideSourceControl(internalName)
+        }
         if $$$ISERR(sc) {
             set ec = $$$ADDSC(ec, sc)
         }
@@ -1173,13 +1186,15 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
                 set ec = $$$ADDSC(ec, $system.OBJ.DeleteProject(name))
             }elseif type = "cls" {
                 set ec = $$$ADDSC(ec, $system.OBJ.Delete(item))
-            }elseif $listfind($listbuild("mac","int","inc","bas","mvb","mvi","dfi"), type) > 0 {
+            }elseif $listfind($listbuild("mac","int","inc","bas","mvb","mvi"), type) > 0 {
                 set ec = $$$ADDSC(ec, ##class(%Routine).Delete(item))
             }elseif type = "csp" {
                 #dim filename = $system.CSP.GetFileName(item)
                 if ##class(%File).Exists(filename) && '##class(%File).Delete(filename) {
                     set ec = $$$ADDSC(ec, ..MakeError("Error while removing "_item))
                 }
+            }elseif ##class(%Library.RoutineMgr).UserType(item) {
+                set ec = $$$ADDSC(ec, ##class(%Library.RoutineMgr).Delete(item))
             } else {
                 set deleted = 0
             }
@@ -1828,4 +1843,3 @@ ClassMethod BuildCEInstallationPackage(ByRef destination As %String) As %Status
 }
 
 }
-

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -38,6 +38,11 @@ ClassMethod TempFolder() As %String
     if context.IsInGitEnabledPackage {
         quit context.Package.Root
     }
+    quit ..DefaultTempFolder()
+}
+
+ClassMethod DefaultTempFolder() As %String
+{
     quit $get(@..#Storage@("settings","namespaceTemp"),..DefaultTemp()_$translate($znspace,"%")_..#Slash)
 }
 
@@ -1124,6 +1129,9 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
 
 ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
 {
+    set refContext = ##class(SourceControl.Git.PackageManagerContext).%Get()
+    set refPackage = refContext.Package
+    
     write !, "==import start=="
     
     #dim err, itemList
@@ -1138,9 +1146,8 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
     for  {
         set internalName = $order(itemList(internalName))
         quit:internalName=""
-        if '..IsInSourceControl(internalName) {
-            continue
-        }
+        set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(internalName)
+        continue:context.Package'=refPackage
         #dim sc as %Status = ..ImportItem(internalName, force)
         if $$$ISERR(sc) {
             set ec = $$$ADDSC(ec, sc)
@@ -1152,8 +1159,13 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
     for  {
         set item = $order(@..#Storage@("TSH", item))
         quit:item=""
-
-        if '##class(%File).Exists(..FullExternalName(item)) {
+        
+        set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(item)
+        continue:context.Package'=refPackage
+            
+        set fullExternalName = ..FullExternalName(item)
+        if '##class(%File).Exists(fullExternalName) {
+            write !,fullExternalName," does not exist - deleting ",item
             #dim type as %String = ..Type(item)
             #dim name as %String = ..NameWithoutExtension(item)
             #dim deleted as %Boolean = 1
@@ -1287,11 +1299,16 @@ ClassMethod ImportAll(force As %Boolean = 0) As %Status
 
 ClassMethod ExportRoutines(force As %Boolean = 0) As %Status
 {
+    set refContext = ##class(SourceControl.Git.PackageManagerContext).%Get()
+    set refPackage = refContext.Package
+    
     #dim item as %String = ""
     #dim ec as %Status = $$$OK
     for  {
         set item = $order(@..#Storage@("items",item))
         quit:item=""
+        set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(item)
+        continue:context.Package'=refPackage
         set ec = ..ExportItem(item, 1, force)
         quit:'ec
     }
@@ -1398,6 +1415,7 @@ ClassMethod GitStatus(ByRef files, IncludeAllFiles = 0)
         set internalName = ..NameToInternalName(externalName)
         if (internalName '= "") {
             set files(internalName) = $listbuild(operation, externalName)
+            set @..#Storage@("items",..NormalizeInternalName(internalName)) = ""
         } elseif ((IncludeAllFiles) && (externalName '= "")) {
             set externalName = $TRANSLATE(externalName, "\", "/")
             set files($I(files)) = $listbuild(operation, externalName)


### PR DESCRIPTION
Fixes #217 

Key changes:
- "Import All" will properly recognize new files
- "Import All" and "Export All" apply only to the current package manager context and disregard items outside that context
- "Import All" treats "Other" document types (DFI, LUT, etc.) properly