### PR TITLE
Add build/test/pre-IRIS-package script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         if: always()
         with:
           name: "PreIRISInstallationPackage"
-          path: ${{ env.GITHUB_WORKSPACE }}/${{ env.artifact_dir }}/*.xml
+          path: ${{ github.workspace }}/${{ env.artifact_dir }}/*.xml
         
       - name: XUnit Viewer
         id: xunit-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           
           # Run InterSystems IRIS Instance
           docker pull $container_image
-          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source:rw -v $GITHUB_WORKSPACE/$test_reports:/$test_reports -v $GITHUB_WORKSPACE/$artifact_dir:/$artifact_dir --init $container_image
+          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source:rw -v $GITHUB_WORKSPACE/$test_reports:/$test_reports:rw -v $GITHUB_WORKSPACE/$artifact_dir:/$artifact_dir:rw --init $container_image
           echo halt > wait
           # Wait for instance to be ready
           until docker exec --interactive $instance iris session $instance < wait; do sleep 1; done
@@ -81,13 +81,14 @@ jobs:
           echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(file)" >> package.script
           echo "halt" >> package.script
           docker exec --interactive $instance iris session $instance -B < package.script
+          ls $GITHUB_WORKSPACE/$artifact_dir
           
       - name: Attach CE Artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:
           name: "PreIRISInstallationPackage"
-          path: ${{ env.artifact_dir }}/*.xml
+          path: ${{ env.GITHUB_WORKSPACE }}/${{ env.artifact_dir }}/*.xml
         
       - name: XUnit Viewer
         id: xunit-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,12 @@ jobs:
           ls $GITHUB_WORKSPACE/$artifact_dir
           
       - name: Attach CE Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: "PreIRISInstallationPackage"
           path: ${{ github.workspace }}/${{ env.artifact_dir }}/*.xml
+          if-no-files-found: error
         
       - name: XUnit Viewer
         id: xunit-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,106 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    env:
+      #Environment variables usable throughout the "build" job, e.g. in OS-level commands
+      
+      # ** FOR GENERAL USE, LIKELY NEED TO CHANGE **
+      package: git-source-control
+      container_image: intersystemsdc/iris-community:latest
+      
+      # ** FOR GENERAL USE, MAY NEED TO CHANGE **
+      build_flags: -dev -verbose
+      test_package: UnitTest
+      
+      # ** FOR GENERAL USE, SHOULD NOT NEED TO CHANGE **
+      instance: iris
+      artifacts: artifacts
+      # Note: test_reports value is duplicated in test_flags environment variable
+      test_reports: test-reports
+      test_flags: >-
+        -verbose -DUnitTest.ManagerClass=TestCoverage.Manager -DUnitTest.JUnitOutput=/test-reports/junit.xml
+        -DUnitTest.FailuresAreFatal=1 -DUnitTest.Manager=TestCoverage.Manager
+        -DUnitTest.UserParam.CoverageReportClass=TestCoverage.Report.Cobertura.ReportGenerator
+        -DUnitTest.UserParam.CoverageReportFile=/source/coverage.xml
+      
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Run Container
+        run: |
+          # Create test_reports directory to share test results before running container
+          mkdir $test_reports
+          chmod 777 $test_reports
+          
+          # Run InterSystems IRIS Instance
+          docker pull $container_image
+          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source:rw -v $GITHUB_WORKSPACE/$test_reports:/$test_reports -v $GITHUB_WORKSPACE/$artifacts:/$artifacts --init $container_image
+          echo halt > wait
+          # Wait for instance to be ready
+          until docker exec --interactive $instance iris session $instance < wait; do sleep 1; done
+      
+      - name: Install TestCoverage
+        run: |
+          echo "zpm \"install testcoverage\":1:1" > install-testcoverage
+          docker exec --interactive $instance iris session $instance -B < install-testcoverage
+          # WOrkaround for permissions issues in TestCoverage (creating directory for source export)
+          chmod 777 $GITHUB_WORKSPACE
+          chmod -R 777 $GITHUB_WORKSPACE/tests/_reference/compare
+          
+          
+      - name: Build and Test
+        run: |
+          # Run build
+          echo "zpm \"load /source $build_flags\":1:1" > build
+          # Test package is compiled first as a workaround for some dependency issues.
+          echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test
+          # Run tests
+          echo "zpm \"$package test -only $test_flags\":1:1" >> test
+          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test &&bash <(curl -s https://codecov.io/bash)
+          
+      - name: Produce CE Artifact
+        run: |
+          # 
+          echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package
+          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifacts/git-source-control-\"_version_\".xml\")" >> package
+          echo "halt" >> package
+          docker exec --interactive $instance iris session $instance -B < package
+          
+      - name: Attache CE Artifact
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: "PreIRISInstallationPackage"
+          path: ${{ artifacts }}
+        
+      - name: XUnit Viewer
+        id: xunit-viewer
+        uses: AutoModality/action-xunit-viewer@v1
+        if: always()
+        with:
+          # With -DUnitTest.FailuresAreFatal=1 a failed unit test will fail the build before this point.
+          # This action would otherwise misinterpret our xUnit style output and fail the build even if
+          # all tests passed.
+          fail: false
+          
+      - name: Attach the report
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: ${{ steps.xunit-viewer.outputs.report-name }}
+          path: ${{ steps.xunit-viewer.outputs.report-dir }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
           echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(file)" >> package.script
           echo "halt" >> package.script
           docker exec --interactive $instance iris session $instance -B < package.script
+          echo $GITHUB_WORKSPACE/$artifact_dir
           ls $GITHUB_WORKSPACE/$artifact_dir
           
       - name: Attach CE Artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ jobs:
       
       # ** FOR GENERAL USE, SHOULD NOT NEED TO CHANGE **
       instance: iris
-      artifacts: artifacts
+      artifact_dir: build-artifacts
+      
       # Note: test_reports value is duplicated in test_flags environment variable
       test_reports: test-reports
       test_flags: >-
@@ -47,9 +48,12 @@ jobs:
           mkdir $test_reports
           chmod 777 $test_reports
           
+          mkdir $artifact_dir
+          chmod 777 $artifact_dir
+          
           # Run InterSystems IRIS Instance
           docker pull $container_image
-          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source:rw -v $GITHUB_WORKSPACE/$test_reports:/$test_reports -v $GITHUB_WORKSPACE/$artifacts:/$artifacts --init $container_image
+          docker run -d -h $instance --name $instance -v $GITHUB_WORKSPACE:/source:rw -v $GITHUB_WORKSPACE/$test_reports:/$test_reports -v $GITHUB_WORKSPACE/$artifact_dir:/$artifact_dir --init $container_image
           echo halt > wait
           # Wait for instance to be ready
           until docker exec --interactive $instance iris session $instance < wait; do sleep 1; done
@@ -77,7 +81,7 @@ jobs:
         run: |
           # 
           echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package
-          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifacts/git-source-control-\"_version_\".xml\")" >> package
+          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifact_dir/git-source-control-\"_version_\".xml\")" >> package
           echo "halt" >> package
           docker exec --interactive $instance iris session $instance -B < package
           
@@ -86,7 +90,7 @@ jobs:
         if: always()
         with:
           name: "PreIRISInstallationPackage"
-          path: ${{ artifacts }}
+          path: ${{ env.artifact_dir }}
         
       - name: XUnit Viewer
         id: xunit-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Produce CE Artifact
         run: |
           echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package.script
-          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifact_dir/git-source-control-\"_version_\".xml\")" >> package.script
+          echo "set file=\"/$artifact_dir/git-source-control-\"_version_\".xml\" write !,file,!" > package.script
+          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(file)" >> package.script
           echo "halt" >> package.script
           docker exec --interactive $instance iris session $instance -B < package.script
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         if: always()
         with:
           name: "PreIRISInstallationPackage"
-          path: ${{ env.artifact_dir }}
+          path: ${{ env.artifact_dir }}/*.xml
         
       - name: XUnit Viewer
         id: xunit-viewer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Produce CE Artifact
         run: |
           echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package.script
-          echo "set file=\"/$artifact_dir/git-source-control-\"_version_\".xml\" write !,file,!" > package.script
+          echo "set file=\"/$artifact_dir/git-source-control-\"_version_\".xml\" write !,file,!" >> package.script
           echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(file)" >> package.script
           echo "halt" >> package.script
           docker exec --interactive $instance iris session $instance -B < package.script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           
       - name: Produce CE Artifact
         run: |
-          echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package.script
+          echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").VersionString" > package.script
           echo "set file=\"/$artifact_dir/git-source-control-\"_version_\".xml\" write !,file,!" >> package.script
           echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(file)" >> package.script
           echo "halt" >> package.script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
           mkdir $test_reports
           chmod 777 $test_reports
           
+          # Same for artifact directory
           mkdir $artifact_dir
           chmod 777 $artifact_dir
           
@@ -62,10 +63,6 @@ jobs:
         run: |
           echo "zpm \"install testcoverage\":1:1" > install-testcoverage
           docker exec --interactive $instance iris session $instance -B < install-testcoverage
-          # WOrkaround for permissions issues in TestCoverage (creating directory for source export)
-          chmod 777 $GITHUB_WORKSPACE
-          chmod -R 777 $GITHUB_WORKSPACE/tests/_reference/compare
-          
           
       - name: Build and Test
         run: |
@@ -85,7 +82,7 @@ jobs:
           echo "halt" >> package
           docker exec --interactive $instance iris session $instance -B < package
           
-      - name: Attache CE Artifact
+      - name: Attach CE Artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,20 +67,19 @@ jobs:
       - name: Build and Test
         run: |
           # Run build
-          echo "zpm \"load /source $build_flags\":1:1" > build
+          echo "zpm \"load /source $build_flags\":1:1" > build.script
           # Test package is compiled first as a workaround for some dependency issues.
-          echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test
+          echo "do \$System.OBJ.CompilePackage(\"$test_package\",\"ckd\") " > test.script
           # Run tests
-          echo "zpm \"$package test -only $test_flags\":1:1" >> test
-          docker exec --interactive $instance iris session $instance -B < build && docker exec --interactive $instance iris session $instance -B < test &&bash <(curl -s https://codecov.io/bash)
+          echo "zpm \"$package test -only $test_flags\":1:1" >> test.script
+          docker exec --interactive $instance iris session $instance -B < build.script && docker exec --interactive $instance iris session $instance -B < test.script &&bash <(curl -s https://codecov.io/bash)
           
       - name: Produce CE Artifact
         run: |
-          # 
-          echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package
-          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifact_dir/git-source-control-\"_version_\".xml\")" >> package
-          echo "halt" >> package
-          docker exec --interactive $instance iris session $instance -B < package
+          echo "set version=##class(%ZPM.PackageManager.Developer.Module).NameOpen(\"git-source-control\").Version" > package.script
+          echo "do ##class(SourceControl.Git.Utils).BuildCEInstallationPackage(\"$artifact_dir/git-source-control-\"_version_\".xml\")" >> package.script
+          echo "halt" >> package.script
+          docker exec --interactive $instance iris session $instance -B < package.script
           
       - name: Attach CE Artifact
         uses: actions/upload-artifact@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Various minor things under the hood to support use without the package manager and/or on older platforms
 
+### Internal
+- Added CI script and tweaked unit tests to run properly in a container and bootstrap their own extension configuration
+
 ## [2.0.5] - 2022-12-02
 
 ### Fixed

--- a/test/UnitTest/SourceControl/Git/AddRemove.cls
+++ b/test/UnitTest/SourceControl/Git/AddRemove.cls
@@ -8,8 +8,6 @@ Method TestInit()
 	new %SourceControl
 	do ##class(%Studio.SourceControl.Interface).SourceControlCreate()
 	set sc = %SourceControl.UserAction(0,"%SourceMenu,Init","","",.action,.target,.msg,.reload)
-	zw sc
-	break
 	do $$$AssertStatusOK(sc)
 }
 

--- a/test/UnitTest/SourceControl/Git/AddRemove.cls
+++ b/test/UnitTest/SourceControl/Git/AddRemove.cls
@@ -50,8 +50,7 @@ Method %OnNew(initvalue) As %Status
 {
 	Merge ..SourceControlGlobal = ^SYS("SourceControl")
 	Kill ^SYS("SourceControl")
-	Set folder = ##class(%Library.File).TempFilename()_"dir"
-	Do ##class(%Library.File).CreateDirectory(folder)
+	Set folder = ##class(%Library.File).NormalizeFilename(##class(%Library.File).TempFilename()_"dir/")
 	Set ^SYS("SourceControl","Git","settings","namespaceTemp") = folder
 	Set ^SYS("SourceControl","Git","settings","mappings","MAC","*")="rtn/"
 	Do ##class(%Studio.SourceControl.Interface).SourceControlClassSet("SourceControl.Git.Extension")

--- a/test/UnitTest/SourceControl/Git/AddRemove.cls
+++ b/test/UnitTest/SourceControl/Git/AddRemove.cls
@@ -3,6 +3,16 @@ Import SourceControl.Git
 Class UnitTest.SourceControl.Git.AddRemove Extends %UnitTest.TestCase
 {
 
+Method TestInit()
+{
+	new %SourceControl
+	do ##class(%Studio.SourceControl.Interface).SourceControlCreate()
+	set sc = %SourceControl.UserAction(0,"%SourceMenu,Init","","",.action,.target,.msg,.reload)
+	zw sc
+	break
+	do $$$AssertStatusOK(sc)
+}
+
 Method TestMac()
 {
 	do $$$AssertEquals(##class(Utils).IsInSourceControl("test.mac"),0)
@@ -32,6 +42,30 @@ Method OnBeforeAllTests() As %Status
 		do r.Compile()
 	}
 	quit $$$OK
+}
+
+Property InitialExtension As %String [ InitialExpression = {##class(%Studio.SourceControl.Interface).SourceControlClassGet()} ];
+
+Property SourceControlGlobal [ MultiDimensional ];
+
+Method %OnNew(initvalue) As %Status
+{
+	Merge ..SourceControlGlobal = ^SYS("SourceControl")
+	Kill ^SYS("SourceControl")
+	Set folder = ##class(%Library.File).TempFilename()_"dir"
+	Do ##class(%Library.File).CreateDirectory(folder)
+	Set ^SYS("SourceControl","Git","settings","namespaceTemp") = folder
+	Set ^SYS("SourceControl","Git","settings","mappings","MAC","*")="rtn/"
+	Do ##class(%Studio.SourceControl.Interface).SourceControlClassSet("SourceControl.Git.Extension")
+	Quit ##super(initvalue)
+}
+
+Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
+{
+	Do ##class(%Studio.SourceControl.Interface).SourceControlClassSet(..InitialExtension)
+	Kill ^SYS("SourceControl")
+	Merge ^SYS("SourceControl") = ..SourceControlGlobal
+	Quit $$$OK
 }
 
 }

--- a/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
+++ b/test/UnitTest/SourceControl/Git/NameToInternalNameTest.cls
@@ -96,9 +96,11 @@ Method OnBeforeAllTests() As %Status
 	set settings = ##class(SourceControl.Git.Settings).%New()
 	set ..OldNamespaceTemp = settings.namespaceTemp
 	set ..OldPercentClassReplace = settings.percentClassReplace
-	set settings.namespaceTemp = $Piece(..Manager.CurrentDir,"test",1)
+	set folder = ##class(%File).NormalizeDirectory(##class(%Library.File).TempFilename()_"dir/")
+	set settings.namespaceTemp = folder
 	set settings.percentClassReplace = "_"
 	$$$ThrowOnError(settings.%Save())
+	do ##class(%Library.File).CopyDir($Piece(..Manager.CurrentDir,"test"),folder,1)
 	merge ..Mappings = @##class(SourceControl.Git.Utils).MappingsNode()
 	kill @##class(SourceControl.Git.Utils).MappingsNode()
 	Set app = $System.CSP.GetDefaultApp($Namespace)
@@ -127,4 +129,3 @@ Method %OnClose() As %Status
 }
 
 }
-

--- a/test/UnitTest/coverage.list
+++ b/test/UnitTest/coverage.list
@@ -1,0 +1,1 @@
+SourceControl.Git.PKG


### PR DESCRIPTION
Fixes #52 (could always do more for unit tests, but this is the first part of the battle).

Also turns out a bit of work is needed to get unit tests running on a container when git-source-control isn't loaded in development mode (vs. on an instance on a Windows machine where it is).