### PR TITLE
Fix <PROTECT> errors rendering menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link from WebUI to Settings page works properly (#230)
 - VSCode Web Views launch in external browser when connecting over unsecured connections (#227)
 - DTL/BPL editing through Studio reflected properly in source control
+- `<PROTECT>` errors rendering menus as a user with limited privileges (%Developer + Ens*)
 
 ## [2.1.0] - 2023-01-23
 

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -45,11 +45,19 @@ Method %Save() As %Status
         quit sc
     }
 
-    set sysStorage = ##class(SourceControl.Git.Utils).InstallNamespaceStorage()
     set storage = ##class(SourceControl.Git.Utils).#Storage
-    kill @sysStorage@("%gitBinPath")
-    if (..gitBinPath '= "") {
-        set @sysStorage@("%gitBinPath") = ..gitBinPath
+    try {
+        set sysStorage = ##class(SourceControl.Git.Utils).%SYSNamespaceStorage()
+        kill @sysStorage@("%gitBinPath")
+        if (..gitBinPath '= "") {
+            set @sysStorage@("%gitBinPath") = ..gitBinPath
+        }
+
+        // Also put in local namespace storage to avoid permissions issues
+        set @storage@("settings","gitBinPath") = ..gitBinPath
+        kill @storage@("settings","gitBinPath")
+    } catch e {
+        // no-op; user might not have privileges.
     }
     kill ^||GitVersion
     
@@ -63,7 +71,7 @@ Method %Save() As %Status
     set @storage@("settings","user",$username,"gitUserEmail") = ..gitUserEmail
     set @storage@("settings","ssh","privateKeyFile") = ..privateKeyFile
     set @storage@("settings","pullEventClass") = ..pullEventClass
-    set @storage@("settings", "percentClassReplace") = ..percentClassReplace
+    set @storage@("settings","percentClassReplace") = ..percentClassReplace
 
     kill @##class(SourceControl.Git.Utils).MappingsNode()
     merge @##class(SourceControl.Git.Utils).MappingsNode() = ..Mappings

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -54,8 +54,8 @@ Method %Save() As %Status
         }
 
         // Also put in local namespace storage to avoid permissions issues
-        set @storage@("settings","gitBinPath") = ..gitBinPath
         kill @storage@("settings","gitBinPath")
+        set @storage@("settings","gitBinPath") = ..gitBinPath
     } catch e {
         // no-op; user might not have privileges.
     }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -16,15 +16,21 @@ Parameter ImportAfterGitMenuItems = ",Commit,Pull,Fetch,Push,";
 
 Parameter GitContextMenuItems = ",%Diff,%Blame,";
 
-ClassMethod InstallNamespaceStorage() As %String [ CodeMode = expression ]
+ClassMethod %SYSNamespaceStorage() As %String [ CodeMode = expression ]
 {
 $Replace(..#Storage,"^","^["""_..#InstallNamespace_"""]")
 }
 
 /// Returns root temp folder
-ClassMethod DefaultTemp() As %String [ CodeMode = expression ]
+ClassMethod DefaultTemp() As %String
 {
-$Get(@..InstallNamespaceStorage()@("%defaultTemp"), "c:\temp\")
+    set defaultTemp = "c:\temp\"
+    try {
+        set defaultTemp = $Get(@..%SYSNamespaceStorage()@("%defaultTemp"), defaultTemp)
+    } catch e {
+        // no-op
+    }
+    quit defaultTemp
 }
 
 ClassMethod MakeError(msg As %String) As %Status [ CodeMode = expression, Private ]
@@ -91,8 +97,13 @@ ClassMethod GitBinPath(Output isDefault) As %String
 {
     set isDefault = 0
     set binPath = "git"
-    if '$data(@..InstallNamespaceStorage()@("%gitBinPath"),binPath)#2 {
-        set isDefault = 1
+    try {
+        if '$data(@..%SYSNamespaceStorage()@("%gitBinPath"),binPath)#2 {
+            set isDefault = 1
+        }
+    } catch e {
+        // no-op; requires git to be on path in this case.
+        // (can't easily change storage location for backward compatibility)
     }
     quit $case($extract(binPath),"""":binPath,:""""_binPath_"""")
 }
@@ -1907,4 +1918,3 @@ ClassMethod BuildCEInstallationPackage(ByRef destination As %String) As %Status
 }
 
 }
-


### PR DESCRIPTION
Fixes #243

Solution:

- Wrap references to IRISSYS namespace globals in try/catch
- Duplicate git bin config in local namespace in addition to instance-wide default (doesn't matter for default temp folder because this is saved first time it's configured)