### PR TITLE
Fix interop deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Link from WebUI to Settings page works properly (#230)
 - VSCode Web Views launch in external browser when connecting over unsecured connections (#227)
-- DTL/BPL editing through Studio reflected properly in source control
+- DTL/BPL editing through Studio reflected properly in source control (#241)
+- Plays nicely with interoperability "Deployment" features (#236)
 
 ## [2.1.0] - 2023-01-23
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -1,7 +1,7 @@
 Import SourceControl.Git
 
 /// Main source control extension class, configured namespace-wide to enable use via VSCode and Studio
-Class SourceControl.Git.Extension Extends %Studio.Extension.Base
+Class SourceControl.Git.Extension Extends %Studio.SourceControl.Base
 {
 
 Parameter DOMAIN = "Studio";
@@ -328,5 +328,10 @@ Method GetStatus(ByRef InternalName As %String, ByRef IsInSourceControl As %Bool
     quit $$$OK
 }
 
+/// Called to add an item to source control.
+Method AddToSourceControl(InternalName As %String, Description As %String = "") As %Status
+{
+	Quit ##class(SourceControl.Git.Utils).AddToSourceControl(InternalName)
 }
 
+}


### PR DESCRIPTION
Fixes #236 

Solution: Extend %Studio.SourceControl.Base instead of %Studio.Extension.Base

Only implements AddToSourceControl - others should be no-ops for purposes of this extension. (We don't want to automatically commit file-by-file, that seems wrong and would be problematic in other deployment contexts.)