### PR TITLE
Use /SHELL to avoid Linux permissions issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Link from WebUI to Settings page works properly (#230)
+- No longer get a "permission deined" message on Linux (#231)
 - VSCode Web Views launch in external browser when connecting over unsecured connections (#227)
 - DTL/BPL editing through Studio reflected properly in source control
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Link from WebUI to Settings page works properly (#230)
-- No longer get a "permission deined" message on Linux (#231)
+- No longer get a "permission denied" message on Linux (#231)
 - VSCode Web Views launch in external browser when connecting over unsecured connections (#227)
 - DTL/BPL editing through Studio reflected properly in source control
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1429,7 +1429,8 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     set errLog = ##class(%Library.File).TempFilename()
 
     set command = $extract(..GitBinPath(),2,*-1)
-    set returnCode = $zf(-100,"/STDOUT="_$$$QUOTE(outLog)_" /STDERR="_$$$QUOTE(errLog)_$case(inFile, "":"", :" /STDIN="_$$$QUOTE(inFile)),command,newArgs...)
+    // Need /SHELL on Linux to avoid permissions errors trying to use root's config
+    set returnCode = $zf(-100,"/SHELL /STDOUT="_$$$QUOTE(outLog)_" /STDERR="_$$$QUOTE(errLog)_$case(inFile, "":"", :" /STDIN="_$$$QUOTE(inFile)),command,newArgs...)
 
     set errStream = ##class(%Stream.FileCharacter).%OpenId(errLog,,.sc)
     set outStream = ##class(%Stream.FileCharacter).%OpenId(outLog,,.sc)


### PR DESCRIPTION
Otherwise tries to use /root/.config/git/attributes - we need irisusr's profile for things to work right

Fixes #231