### PR TITLE
Fix error pulling multiple add/deletes of non-IRIS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Studio export path doesn't get weird mixed slahes on Windows (#252)
+- Pulling add/delete of multiple non-IRIS files no longer causes error (#273)
 
 ## [2.2.0] - 2023-06-05
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -409,11 +409,15 @@ ClassMethod Pull(remote As %String = "origin", preview As %Boolean = 0) As %Stat
     while(key '= "") {
         set modification = files(key)
         if (modification.changeType = "D"){
-            set deletedFiles = deletedFiles_","_modification.internalName
+            if (modification.internalName '= "") {
+                set deletedFiles = deletedFiles_","_modification.internalName
+            }
         } elseif (modification.changeType = "A"){
             set modification.internalName = ##class(SourceControl.Git.Utils).NameToInternalName(modification.externalName,,0)
-            set addedFiles = addedFiles_","_modification.internalName
-            set files(key) = modification
+            if (modification.internalName '= "") {
+                set addedFiles = addedFiles_","_modification.internalName
+                set files(key) = modification
+            }
         }
         set key = $order(files(key))
     }
@@ -1983,3 +1987,4 @@ ClassMethod BuildCEInstallationPackage(ByRef destination As %String) As %Status
 }
 
 }
+


### PR DESCRIPTION
Fixes #273 

If we pull an add/delete to a file with no internal name, do not add/delete it from server-side source control.