### PR TITLE
Don't show Failed to Import popup after overwriting the file on server once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for git submodules in package manager-aware setting (#305)
 - Web UI's 'More ...' view shows longer branch names (#294)
 - Deletion of files in locked environment is now suppressed (#302)
+- Failed to import file VS Code popup no longer shows up after overwriting file on server once (#264)
 
 ## [2.3.0] - 2023-12-06
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -210,6 +210,21 @@ Method OnBeforeLoad(InternalName As %String, verbose As %Boolean) As %Status
 /// Called before Studio checks for the timestamp of an item.
 Method OnBeforeTimestamp(InternalName As %String)
 {
+    set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(InternalName)
+    if $IsObject($Get(%request)) {
+        set clientServerHash = ##class(%Atelier.REST).GetClientServerHash()
+        if (clientServerHash '= "") {
+            // suppress load / timestamp update if file on server was modified an extremely short time ago
+            set file = ##class(SourceControl.Git.Utils).FullExternalName(InternalName)
+            if (file '= "") {
+                set lastModifiedTime = ##class(%Library.File).GetFileDateModified(file)
+                set diff = $System.SQL.Functions.DATEDIFF("ms",lastModifiedTime,$h)
+                if (diff < 1000) {
+                    quit
+                }
+            }
+        }
+    }
     quit ..OnBeforeLoad(InternalName,0)
 }
 
@@ -351,4 +366,3 @@ Method AddToSourceControl(InternalName As %String, Description As %String = "") 
 }
 
 }
-


### PR DESCRIPTION
This fixes #264.

Testing Steps:
1. In git-source-control repo, checkout overwrite-server-popup branch
```
git checkout overwrite-server-popup
```
2. In VS Code, click the ObjectScript icon in the left side menu to open ObjectScript Explorer window, click "Choose Server and Namespace" and sign in using InterSystems Server Credentials.
3. Load git-source-control into the current namespace
```
zpm "load <path to local git-source-control repo cloned in step 1>"
```
4. Modify a file you haven't overwritten on server
5. Save the file you modified in step 3. Verify that "Failed to import" VS Code popup shows up on the first time you modify and save the file.
6. Click "Overwrite on Server"
7. Modify file from step 3 and save the file. Verify that "Failed to import" VS Code popup no longer shows up.
8. Undo changes to file you modified.