### PR TITLE
Adding new file over isfs no longer throws "system cannot find the file specified" error

### DIFF
--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -216,7 +216,7 @@ Method OnBeforeTimestamp(InternalName As %String)
         if (clientServerHash '= "") {
             // suppress load / timestamp update if file on server was modified an extremely short time ago
             set file = ##class(SourceControl.Git.Utils).FullExternalName(InternalName)
-            if (file '= "") {
+            if (file '= "" && ##class(%File).Exists(file)) {
                 set lastModifiedTime = ##class(%Library.File).GetFileDateModified(file)
                 set diff = $System.SQL.Functions.DATEDIFF("ms",lastModifiedTime,$h)
                 if (diff < 1000) {
@@ -366,3 +366,4 @@ Method AddToSourceControl(InternalName As %String, Description As %String = "") 
 }
 
 }
+


### PR DESCRIPTION
Testing Steps
1. Add a new .cls file in SourceControl.Git over isfs server-side editing.
2. Check that the new file now exists under SourceControl.Git and no error was thrown.