### PR TITLE
Don't automatically stage files added to source control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web UI's 'More ...' view shows longer branch names (#294)
 - Deletion of files in locked environment is now suppressed (#302)
 - Failed to import file VS Code popup no longer shows up after overwriting file on server once (#264)
+- Don't automatically stage files added to source control (#303)
 
 ## [2.3.0] - 2023-12-06
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -216,7 +216,7 @@ Method OnBeforeTimestamp(InternalName As %String)
         if (clientServerHash '= "") {
             // suppress load / timestamp update if file on server was modified an extremely short time ago
             set file = ##class(SourceControl.Git.Utils).FullExternalName(InternalName)
-            if (file '= "") {
+            if (file '= "" && ##class(%File).Exists(file)) {
                 set lastModifiedTime = ##class(%Library.File).GetFileDateModified(file)
                 set diff = $System.SQL.Functions.DATEDIFF("ms",lastModifiedTime,$h)
                 if (diff < 1000) {
@@ -366,3 +366,4 @@ Method AddToSourceControl(InternalName As %String, Description As %String = "") 
 }
 
 }
+

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -2120,18 +2120,27 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
             $.get("api/uncommitted", function (uncommitted) {
                 var uncommittedItems = JSON.parse(uncommitted);
                 self.filesCount = 0;
+                var filePaths = [];
                 webui.splitLines(data).forEach(function(line) {
+                    var indexStatus = line[0];
+                    var workingTreeStatus = line[1];
                     var status = line[col];
-                    if (col == 0 && status != " " && status != "?" || col == 1 && status != " ") {
+                    line = line.substring(3);
+                    var splitted = line.split(" -> ");
+                    var model;
+                    if (splitted.length > 1) {
+                        model = splitted[1];
+                    } else {
+                        model = line;
+                    }
+                    filePaths.push(model);
+
+                    if (workingTreeStatus === "D") {
+                        localStorage.removeItem(model);
+                    }
+
+                    if (col == 0 && indexStatus != " " && indexStatus != "?" && localStorage.getItem(model) !== null || col == 1 && workingTreeStatus != " " && workingTreeStatus != "D" && localStorage.getItem(model) === null) {
                         ++self.filesCount;
-                        line = line.substring(3);
-                        var splitted = line.split(" -> ");
-                        var model;
-                        if (splitted.length > 1) {
-                            model = splitted[1];
-                        } else {
-                            model = line;
-                        }
                         var isForCurrentUser;
                         if(model.indexOf(" ") > -1){
                             isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
@@ -2156,6 +2165,13 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         }
                     }
                 });
+
+                Object.keys(localStorage).filter(function (key) {
+                    return !filePaths.includes(key);
+                }).map(function (key) {
+                    localStorage.removeItem(key);
+                });
+                
                 if (selectedIndex !== null && selectedIndex >= fileList.childElementCount) {
                     selectedIndex = fileList.childElementCount - 1;
                     if (selectedIndex == -1) {
@@ -2320,6 +2336,12 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
         var action = type == "working-copy" ? "stage" : "unstage"
         var files = self.getFileList(undefined, "D", 0);
         var rmFiles = self.getFileList("D", undefined, 0);
+
+        if (action === "stage") {
+            localStorage.setItem(files.trim(), "staged");
+        } else {
+            localStorage.removeItem(files.trim());
+        }
 
         if (files.length != 0) {
             var cmd = type == "working-copy" ? "add" : "reset";


### PR DESCRIPTION
This fixes #303 

Testing Steps:
1. In git-source-control repo, checkout noStagingForAdd branch
```
git checkout noStagingForAdd
```
2. Load git-source-control into the current namespace
```
zpm "load <path to local git-source-control repo>"
```
3. Create a new class.
4. Add the class file to source control.
```
git add <path to file>
```
5. In Management Portal Favorites section, open git-source-control UI and click Workspace on the side navigation menu.
6. Verify that the new class you added in step 3 doesn't show up in Working Copy or Staging Area sections. 
7. Modify the class you added in step 3 and save.
8. Verify that the class now shows up in the Working Copy section.
9. Click "Stage" button in Working Copy section.
10. Verify that the class now shows up in the Staging Area section and is no longer in Working Copy section.
11. Refresh the page, click Workspace on the side navigation menu and verify that the class still shows up in the Staging Area section.
12. Click "Unstage" button in Staging Area section.
13. Verify that the class now shows up in the Working Copy section and is no longer in Staging Area section.
14. Delete the class you added in step 3, refresh the page, click Workspace on the side navigation menu and verify that the class is no longer in Working Copy or Staging Area sections.