### PR TITLE
Checkout branch name with slash via Web UI no longer fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deletion of files in locked environment is now suppressed (#302)
 - Failed to import file VS Code popup no longer shows up after overwriting file on server once (#264)
 - Don't automatically stage files added to source control (#303)
+- Checkout of branches whose names contain slashes via Web UI no longer fails (#295)
 
 ## [2.3.0] - 2023-12-06
 


### PR DESCRIPTION
This fixes #295 

Testing Steps:
1. In git-source-control repo, checkout branchNameWithSlash
```
git checkout branchNameWithSlash
```
2. Load git-source-control into the current namespace
```
zpm "load <path to local git-source-control repo>"
```
3. Create a branch with a name containing a slash
```
git checkout -b  feature/chgNNNNNN_some_description
git push --set-upstream origin feature/chgNNNNNN_some_description
```
(enter passcode for deploy key if prompted)
```
git checkout branchNameWithSlash
```
4. In Management Portal Favorites section, open git-source-control UI.
5. Under the Remote Branches section of the side navigation menu, click More ... > origin/feature/chgNNNNNN_some_description > Checkout Branch. Check that "Switched to branch 'feature/chgNNNNNN_some_description'" popup shows up at the top of the page and  feature/chgNNNNNN_some_description is bolded under the Local Branches section of the side navigation menu.
6. Under the Local Branches section of the side navigation menu, click branchNameWithSlash > Checkout Branch. 
7. Under the Local Branches section of the side navigation menu, click feature/chgNNNNNN_some_description > Checkout Branch. Check that "Switched to branch 'feature/chgNNNNNN_some_description'" popup shows up at the top of the page and feature/chgNNNNNN_some_description is bolded under the Local Branches section of the side navigation menu.
8. Under the Local Branches section of the side navigation menu, click branchNameWithSlash > Checkout Branch. 
9. Delete the branch created in step 3.
```
git push origin --delete feature/chgNNNNNN_some_description
```
(enter passcode for deploy key if prompted)
```
git branch -d feature/chgNNNNNN_some_description
```