### PR TITLE
Show other developer's username in Web UI's workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failed to import file VS Code popup no longer shows up after overwriting file on server once (#264)
 - Don't automatically stage files added to source control (#303)
 - Checkout of branches whose names contain slashes via Web UI no longer fails (#295)
+- Display other developer's username in Web UI's Workspace when hovering over the name of a file they changed (#304)
 
 ## [2.3.0] - 2023-12-06
 

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -44,7 +44,9 @@ ClassMethod RemoveUncommitted(FileList, Display = 1, Revert = 0, ActiveCommit = 
             set changeSourceClass=##class(%Studio.SourceControl.Interface).SourceControlClassGet()
         }
         if ('$get(^SYS("SourceControl","ChangeConfig","KeepHistory")))||(Revert) {
-            set sc=..%DeleteId(obj.%Id())
+            if (obj.ChangedBy = $username) {
+                set sc=..%DeleteId(obj.%Id())
+            }
         } else {
             if $get(CommitCCR)'="" set obj.CCR=CommitCCR
             set obj.P4Issued=$zdatetime($h,3)
@@ -75,6 +77,31 @@ ClassMethod IsUncommitted(Filename, ByRef ID) As %Boolean
         set ID=""
         quit 0
     }
+}
+
+ClassMethod GetOtherDeveloperChanges() As %Boolean
+{
+    set numEntries = 0
+    set fileToOtherDevelopers = {}
+    set query = "Select ItemFile, ChangedBy FROM SourceControl_Git.Change WHERE CHARINDEX('SourceControl.Git', Name)>0 AND Committed = '0' AND ChangedBy != '"_$username_"'"
+    set statement = ##class(%SQL.Statement).%New()
+    set status = statement.%Prepare(query)
+    if $$$ISERR(status) {
+        write "%Prepare failed:" do $SYSTEM.Status.DisplayError(status)
+        quit
+    }
+    set rset = statement.%Execute()
+    if (rset.%SQLCODE '= 0) {
+        write "%Execute failed:", !, "SQLCODE ", rset.%SQLCODE, ": ", rset.%Message
+        quit
+    }
+    while rset.%Next() {
+        set filePath = "cls\"_$EXTRACT(rset.ItemFile, $FIND(rset.ItemFile,"cls\"),$LENGTH(rset.ItemFile))
+        set otherDevelopers = fileToOtherDevelopers.%Get(filePath, [])
+        do otherDevelopers.%Push(rset.ChangedBy)
+        do fileToOtherDevelopers.%Set(filePath, otherDevelopers)
+    }
+    return fileToOtherDevelopers
 }
 
 /// Goes through Uncommitted queue and removes any items of action 'edit' or 'add' which are ReadOnly or non-existent on the filesystem
@@ -179,4 +206,3 @@ Storage Default
 }
 
 }
-

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -98,6 +98,7 @@ ClassMethod GetOtherDeveloperChanges() As %Boolean
         do otherDevelopers.%Push(rset.ChangedBy)
         do fileToOtherDevelopers.%Set(filePath, otherDevelopers)
     }
+    $$$ThrowOnError(sc)
     return fileToOtherDevelopers
 }
 

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -83,19 +83,16 @@ ClassMethod GetOtherDeveloperChanges() As %Boolean
 {
     set numEntries = 0
     set fileToOtherDevelopers = {}
-    set query = "Select ItemFile, ChangedBy FROM SourceControl_Git.Change WHERE CHARINDEX('SourceControl.Git', Name)>0 AND Committed = '0' AND ChangedBy != '"_$username_"'"
+    set query = "Select ItemFile, ChangedBy FROM SourceControl_Git.Change WHERE CHARINDEX('SourceControl.Git', Name)>0 AND Committed = '0' AND ChangedBy <> ?"
     set statement = ##class(%SQL.Statement).%New()
     set status = statement.%Prepare(query)
-    if $$$ISERR(status) {
-        write "%Prepare failed:" do $SYSTEM.Status.DisplayError(status)
-        quit
+    $$$ThrowOnError(status)
+    set rset = statement.%Execute($username)
+    if (rset.%SQLCODE < 0) {
+        throw ##class(%Exception.SQL).CreateFromSQLCODE(rset.%SQLCODE,rset.%Message)
     }
-    set rset = statement.%Execute()
-    if (rset.%SQLCODE '= 0) {
-        write "%Execute failed:", !, "SQLCODE ", rset.%SQLCODE, ": ", rset.%Message
-        quit
-    }
-    while rset.%Next() {
+    while rset.%Next(.sc) {
+        $$$ThrowOnError(sc)
         set filePath = "cls\"_$EXTRACT(rset.ItemFile, $FIND(rset.ItemFile,"cls\"),$LENGTH(rset.ItemFile))
         set otherDevelopers = fileToOtherDevelopers.%Get(filePath, [])
         do otherDevelopers.%Push(rset.ChangedBy)

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -178,24 +178,26 @@ ClassMethod Uncommitted() As %SystemBase
     set output = ""
     set key = ""
 
-    set array = []
-    set key = ""
+    set editedByCurrentUser = []
+    set fileToOtherDevelopers = {}
     for {
         set key = $order(files(key),1,fileData)
         quit:key=""
         // Check that current user has files(key) uncommitted and only %Push if they do
         set filename = ##class(Utils).FullExternalName(key)
         if (($ISVALIDNUM(key)) && (files(key) '= "")){
-            do array.%Push($listget(fileData,2))
+            do editedByCurrentUser.%Push($listget(fileData,2))
         }
         else{
             set sc=##class(SourceControl.Git.Change).GetUncommitted(filename,.tAction,.tInternalName,.UncommittedUser,.tSource,.UncommittedLastUpdated)
             if ($$$ISOK(sc)) && ($data(tAction)&&(UncommittedUser=$username)) {
-                do array.%Push($listget(fileData,2))
+                do editedByCurrentUser.%Push($listget(fileData,2))
             }
         }
     }
-    quit array
+    do fileToOtherDevelopers.%Set("current user's changes", editedByCurrentUser)
+    do fileToOtherDevelopers.%Set("other users' changes", ##class(SourceControl.Git.Change).GetOtherDeveloperChanges())
+    quit fileToOtherDevelopers
 }
 
 ClassMethod GetURLPrefix(%request As %CSP.Request, URL As %String) As %String
@@ -218,4 +220,3 @@ ClassMethod GetSettingsURL(%request As %CSP.Request) As %SystemBase
 }
 
 }
-

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -414,7 +414,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
             var flag = 0;
             webui.git("status -u --porcelain", function(data) {
                 $.get("api/uncommitted", function (uncommitted) {
-                    var uncommittedItems = JSON.parse(uncommitted);
+                    var uncommittedItems = JSON.parse(uncommitted)["current user's changes"];
                     var col = 1
                     webui.splitLines(data).forEach(function(line) {
                         var status = line[col];
@@ -488,7 +488,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
         var flag = 0;
         webui.git("status -u --porcelain", function(data) {
             $.get("api/uncommitted", function (uncommitted) {
-                var uncommittedItems = JSON.parse(uncommitted);
+                var uncommittedItems = JSON.parse(uncommitted)["current user's changes"];
                 var col = 1
                 webui.splitLines(data).forEach(function(line) {
                     var status = line[col];
@@ -2143,13 +2143,30 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
         var col = type == "working-copy" ? 1 : 0;
         webui.git("status -u --porcelain", function(data) {
             $.get("api/uncommitted", function (uncommitted) {
-                var uncommittedItems = JSON.parse(uncommitted);
+                var uncommittedItems = JSON.parse(uncommitted)["current user's changes"];
+                var otherDeveloperUncommittedItems = JSON.parse(uncommitted)["other users' changes"];
                 self.filesCount = 0;
                 var filePaths = [];
+                function addItemToFileList(fileList, otherDeveloperUsername, model) {
+                    var isForCurrentUser = otherDeveloperUsername === ""? true : false;
+                    var cssClass = isForCurrentUser ? 'list-group-item available' : 'list-group-item unavailable';
+                    if(isForCurrentUser){
+                        var item = $('<a class="'+cssClass+'">').prependTo(fileList)[0];
+                    }
+                    else{
+                        var item = $('<a class="'+cssClass+'" data-toggle="tooltip" title='+otherDeveloperUsername+'>'+
+                                    webui.peopleIcon).appendTo(fileList)[0];
+                    }
+                    item.model = model;
+                    item.appendChild(document.createTextNode(model));
+                    if (isForCurrentUser) {
+                        $(item).click(self.select);
+                        $(item).dblclick(self.process);
+                    }
+                }
                 webui.splitLines(data).forEach(function(line) {
                     var indexStatus = line[0];
                     var workingTreeStatus = line[1];
-                    var status = line[col];
                     line = line.substring(3);
                     var splitted = line.split(" -> ");
                     var model;
@@ -2159,10 +2176,15 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         model = line;
                     }
                     filePaths.push(model);
+
                     if (workingTreeStatus === "D") {
                         localStorage.removeItem(model);
                     }
-                    if (col == 0 && indexStatus != " " && indexStatus != "?" && localStorage.getItem(model) !== null || col == 1 && workingTreeStatus != " " && workingTreeStatus != "D" && localStorage.getItem(model) === null) {
+
+                    var isNotStaged= workingTreeStatus != "D" && workingTreeStatus != " " && localStorage.getItem(model) === null;
+                    var addUnstagedFile = col == 1 && isNotStaged;
+                    var addStagedFile = col == 0 && indexStatus != " " && indexStatus != "?" && localStorage.getItem(model) !== null;
+                    if (addUnstagedFile || addStagedFile) {
                         ++self.filesCount;
                         var isForCurrentUser;
                         if(model.indexOf(" ") > -1){
@@ -2170,29 +2192,31 @@ webui.ChangedFilesView = function(workspaceView, type, label) {
                         } else {
                             isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
                         }
-                        var cssClass = isForCurrentUser ? 'list-group-item available' : 'list-group-item unavailable';
-
-                        if(isForCurrentUser){
-                            var item = $('<a class="'+cssClass+'">').prependTo(fileList)[0];
-                        }
-                        else{
-                            var item = $('<a class="'+cssClass+'">'+
-                                        webui.peopleIcon).appendTo(fileList)[0];
-                        }
-                        item.model = model;
-                        item.status = status;
-                        item.appendChild(document.createTextNode(line));
-                        $(item).click(self.select);
+                        
                         if (isForCurrentUser) {
-                            $(item).dblclick(self.process);
+                            addItemToFileList(fileList, "", model);
                         }
                     }
                 });
+
+                for (const otherDeveloperItem of Object.keys(otherDeveloperUncommittedItems)) {
+                    for (const otherDeveloperUsername of otherDeveloperUncommittedItems[otherDeveloperItem]) {
+                        if (col==1) {
+                            addItemToFileList(fileList, otherDeveloperUsername, otherDeveloperItem);
+                        }
+                    }
+                }
+                
+                $(function () {
+                    $('[data-toggle="tooltip"]').tooltip()
+                });
+
                 Object.keys(localStorage).filter(function (key) {
                     return !filePaths.includes(key);
                 }).map(function (key) {
                     localStorage.removeItem(key);
                 });
+                
                 if (selectedIndex !== null && selectedIndex >= fileList.childElementCount) {
                     selectedIndex = fileList.childElementCount - 1;
                     if (selectedIndex == -1) {


### PR DESCRIPTION
This fixes #304 

Testing Steps:

1. In git-source-control repo, checkout otherDevUsername
```
git checkout otherDevUsername
```
2. Load git-source-control into the current namespace
```
zpm "load <path to local git-source-control repo>"
```
3. In Management Portal, navigate to SourceControl_Git.Change table's Execute Query tab (System Explorer > SQL > Tables > SourceControl_Git.Change).
4. Execute the following Insert query:
```
INSERT INTO SourceControl_Git.Change (Action, ChangedBy, Committed, CommittedTime, CommittedTimeDisplay, InternalName, ItemFile, Name) VALUES ('edit','abcd', '0', '1840-12-31 00:00:01', 'uncommitted', 'SourceControl.Git.TestDelete.CLS', 'C:\Users\abcd\git-source-control\cls\SourceControl\Git\TestDelete.cls','SourceControl.Git.TestDelete.CLS');
```
5. In Management Portal Favorites section, open git-source-control UI and click Workspace on the side navigation menu.
6. Hover over "cls\SourceControl\Git\TestDelete.cls" in Working Copy section and verify that a popup containing username "abcd" is displayed.
7.  In Management Portal, navigate to SourceControl_Git.Change table's Execute Query tab (System Explorer > SQL > Tables > SourceControl_Git.Change).
8. Execute the following Delete query:
```
DELETE from SourceControl_Git.Change where ChangedBy='abcd' and ItemFile='C:\Users\abcd\git-source-control\cls\SourceControl\Git\TestDelete.cls'
```
9. Refresh git-source-control UI, navigate to Workspace tab and verify that "cls\SourceControl\Git\TestDelete.cls" is no longer displayed in Working Copy section.