### PR TITLE
Handle file deletion in incremental load PullEventHandler and throw errors (if any) instead of returning Success Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Performance improvements (#269, #315)
 - Checkout of branches whose names contain slashes via Web UI no longer fails (#295)
 - Display other developer's username in Web UI's Workspace when hovering over the name of a file they changed (#304)
+- Incremental load PullEventHandler now handles file deletion (#299)
+- Incremental load PullEventHandler no longer returns a Success Status if an error was thrown during the pull process (#300)
 
 ## [2.3.0] - 2023-12-06
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -275,7 +275,7 @@ Method OnBeforeDelete(InternalName As %String) As %Status
         set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(InternalName)
         set InternalName = ##class(Utils).NormalizeInternalName(InternalName)
         set Filename = ##class(Utils).FullExternalName(InternalName)
-        if ##class(Utils).IsInSourceControl(InternalName) {
+        if ##class(Utils).IsInSourceControl(InternalName) && ##class(%File).Exists(Filename) {
             quit ##class(Change).AddDeletedToUncommitted(Filename, InternalName)
         }
         quit $$$OK

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -17,8 +17,12 @@ Method OnPull() As %Status
         if ((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) {
             write !, ..ModifiedFiles(i).externalName, " was not imported into the database and will not be compiled. "
         } elseif (..ModifiedFiles(i).changeType = "D") {
-            $$$ThrowOnError(..DeleteFile(internalName))
-            write !, ..ModifiedFiles(i).externalName, " was deleted."
+            set sc = ..DeleteFile(internalName)
+            if sc {
+                write !, ..ModifiedFiles(i).externalName, " was deleted."
+            } else {
+                write !, "Deletion of ", ..ModifiedFiles(i).externalName, " failed."
+            }
         } else {
             set compilelist(internalName) = ""
             set nFiles = nFiles + 1
@@ -38,13 +42,12 @@ Method DeleteFile(item As %String)
 {
     set type = ##class(SourceControl.Git.Utils).Type(item)
     if (type = "cls") {
-        do $System.OBJ.Delete(item)
+        quit $System.OBJ.Delete(item)
     } elseif (type = "csp") {
-        do $System.CSP.DeletePage(item)
+        quit $System.CSP.DeletePage(item)
     } else {
-        do ##class(%Library.RoutineMgr).Delete(item)
+        quit ##class(%Library.RoutineMgr).Delete(item)
     }
-    Quit $$$OK
 }
 
 }

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -21,7 +21,7 @@ Method OnPull() As %Status
             if sc {
                 write !, ..ModifiedFiles(i).externalName, " was deleted."
             } else {
-                write !, "Deletion of ", ..ModifiedFiles(i).externalName, " failed."
+                write !, "WARNING: Deletion of ", ..ModifiedFiles(i).externalName, " failed."
             }
         } else {
             set compilelist(internalName) = ""

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -14,8 +14,11 @@ Method OnPull() As %Status
 
     for i=1:1:$get(..ModifiedFiles){
         set internalName = ..ModifiedFiles(i).internalName
-        if (((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) || (..ModifiedFiles(i).changeType = "D")) {
+        if ((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) {
             write !, ..ModifiedFiles(i).externalName, " was not imported into the database and will not be compiled. "
+        } elseif (..ModifiedFiles(i).changeType = "D") {
+            $$$ThrowOnError(..DeleteFile(internalName))
+            write !, ..ModifiedFiles(i).externalName, " was deleted."
         } else {
             set compilelist(internalName) = ""
             set nFiles = nFiles + 1
@@ -31,5 +34,17 @@ Method OnPull() As %Status
     quit $system.OBJ.CompileList(.compilelist, "cukb")
 }
 
+Method DeleteFile(item As %String)
+{
+    set type = ##class(SourceControl.Git.Utils).Type(item)
+    if (type = "cls") {
+        do $System.OBJ.Delete(item)
+    } elseif (type = "csp") {
+        do $System.CSP.DeletePage(item)
+    } else {
+        do ##class(%Library.RoutineMgr).Delete(item)
+    }
+    Quit $$$OK
 }
 
+}

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -14,12 +14,13 @@ Method OnPull() As %Status
 
     for i=1:1:$get(..ModifiedFiles){
         set internalName = ..ModifiedFiles(i).internalName
-        if ((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) {
+        if (((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) || (..ModifiedFiles(i).changeType = "D")) {
             write !, ..ModifiedFiles(i).externalName, " was not imported into the database and will not be compiled. "
         } else {
             set compilelist(internalName) = ""
             set nFiles = nFiles + 1
             set loadSC = $$$ADDSC(loadSC,##class(SourceControl.Git.Utils).ImportItem(internalName, 1))
+            $$$ThrowOnError(loadSC)
         }
     }
 

--- a/cls/SourceControl/Git/TestDelete.cls
+++ b/cls/SourceControl/Git/TestDelete.cls
@@ -1,4 +1,0 @@
-Class SourceControl.Git.TestDelete Extends %RegisteredObject
-{
-
-}

--- a/cls/SourceControl/Git/TestDelete.cls
+++ b/cls/SourceControl/Git/TestDelete.cls
@@ -1,0 +1,4 @@
+Class SourceControl.Git.TestDelete Extends %RegisteredObject
+{
+
+}

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -355,7 +355,7 @@ ClassMethod Pull(remote As %String = "origin", preview As %Boolean = 0) As %Stat
     write !, "Fetch done"
     write !, "Files that will be modified by git pull: "
 
-    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errStream,.outStream, (branchName_"..."_(remote_"/"_branchName)), "--name-status")
+    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errStream,.outStream, remote_"/"_branchName, "--name-status")
     while (outStream.AtEnd = 0) {
         set file = outStream.ReadLine()
         set modification = ##class(SourceControl.Git.Modification).%New()


### PR DESCRIPTION
This fixes #299 , #300 
Testing Steps:
1. Delete a class in a repo.
2. Run
```
w ##class(SourceControl.Git.API).Pull()
```
3. Verify that no error messages (Error # ...) are printed in terminal. Instead, "<name of file deleted in step 1> was not imported into the database and will not be compiled." should be printed in terminal.