### PR TITLE
Git pull correctly actions modified files

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -355,7 +355,7 @@ ClassMethod Pull(remote As %String = "origin", preview As %Boolean = 0) As %Stat
     write !, "Fetch done"
     write !, "Files that will be modified by git pull: "
 
-    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errStream,.outStream, remote_"/"_branchName, "--name-status")
+    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errStream,.outStream, branchName_".."_remote_"/"_branchName, "--name-status")
     while (outStream.AtEnd = 0) {
         set file = outStream.ReadLine()
         set modification = ##class(SourceControl.Git.Modification).%New()
@@ -2036,3 +2036,4 @@ ClassMethod ResetSourceControlClass()
 }
 
 }
+


### PR DESCRIPTION
Fixes #323 

The git diff now shows differences from the opposite side. So a file added on the remote branch is treated as an add rather than a delete, and vice versa.
I think no changelog required because this fixes unintended behavior from an unreleased change #320.