### PR TITLE
Issue #317 IPM Multi Developer Setting Issue Resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Items mapped from database other than namespace's default routine database are now ignored by default when exporting or adding files
 - New setting to configure whether mapped items should be should be treated as read-only
+- Now skips files belonging to other git enabled packages in `##class(SourceControl.Git.Change).RefreshUncommitted()`
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -128,12 +128,16 @@ ClassMethod RefreshUncommitted(Display = 0, IncludeRevert = 0, Output gitFiles, 
     // Remove entries in the uncommitted queue that don't correspond to changes as tracked by git
     set filename="", filename=$order(tFileList(filename),1,action)
     while (filename'="") {       
-        Set ^mtemphw("filename", $i(^mtemphw("filename"))) = filename
         set examine=$select(action="add":1,action="edit":1,action="delete":1, IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
 
+        set context = ##class(SourceControl.Git.PackageManagerContext).%Get()
+        set packageRoot = context.Package.Root
         set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
-        Set ^mtemphw("internalfilename", $i(^mtemphw("internalfilename"))) = InternalName
+
+        // skip files belonging to other git enabled packages
+        if ($EXTRACT(filename, 1, $LENGTH(packageRoot)) = packageRoot) continue
+        
 
         if (('##class(%File).Exists(filename)) || (InternalName = "") || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && 
             (($data($$$TrackedItems(InternalName))) || ##class(SourceControl.Git.Utils).NormalizeExtension($data($$$TrackedItems(InternalName))))))  {

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -128,10 +128,12 @@ ClassMethod RefreshUncommitted(Display = 0, IncludeRevert = 0, Output gitFiles, 
     // Remove entries in the uncommitted queue that don't correspond to changes as tracked by git
     set filename="", filename=$order(tFileList(filename),1,action)
     while (filename'="") {       
+        Set ^mtemphw("filename", $i(^mtemphw("filename"))) = filename
         set examine=$select(action="add":1,action="edit":1,action="delete":1, IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
 
         set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
+        Set ^mtemphw("internalfilename", $i(^mtemphw("internalfilename"))) = InternalName
 
         if (('##class(%File).Exists(filename)) || (InternalName = "") || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && 
             (($data($$$TrackedItems(InternalName))) || ##class(SourceControl.Git.Utils).NormalizeExtension($data($$$TrackedItems(InternalName))))))  {

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -131,12 +131,11 @@ ClassMethod RefreshUncommitted(Display = 0, IncludeRevert = 0, Output gitFiles, 
         set examine=$select(action="add":1,action="edit":1,action="delete":1, IncludeRevert&&(action="revert"):1,1:0)
         if 'examine set filename=$order(tFileList(filename),1,action) continue
 
-        set context = ##class(SourceControl.Git.PackageManagerContext).%Get()
-        set packageRoot = context.Package.Root
+        set packageRoot = ##class(SourceControl.Git.Utils).TempFolder()
         set InternalName = ##class(SourceControl.Git.Utils).NameToInternalName(filename,0,0)
 
         // skip files belonging to other git enabled packages
-        if ($EXTRACT(filename, 1, $LENGTH(packageRoot)) = packageRoot) continue
+        if ($EXTRACT(filename, 1, $LENGTH(packageRoot)) '= packageRoot) continue
         
 
         if (('##class(%File).Exists(filename)) || (InternalName = "") || ((InternalName '= "") && ('$data(gitFiles(InternalName), found)) && 


### PR DESCRIPTION
Files that belong to other Git enabled IPM packages are now skipped when removing files in ##class(SourceControl.Git.Change).RefreshUncommitted().