### PR TITLE
Issue #351 added branch property to the PullEventHandler class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-release support for IPM v0.9.0+
 - Items mapped from database other than namespace's default routine database are now ignored by default when exporting or adding files
 - New setting to configure whether mapped items should be should be treated as read-only
+- Added a new "Branch" parameter to `##class(SourceControl.Git.PullEventHandler)` (#351)
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -13,6 +13,9 @@ Property LocalRoot As %String(MAXLEN = "");
 /// Modified files (integer-subscripted array storing objects of class SourceControl.Git.Modification)
 Property ModifiedFiles [ MultiDimensional ];
 
+/// The branch that is checked out before OnPull() is called
+Property Branch [ InitialExpression = {##class(SourceControl.Git.Utils).GetCurrentBranch()} ];
+
 Method OnPull() As %Status [ Abstract ]
 {
 }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -344,6 +344,12 @@ ClassMethod Fetch(ByRef diffFiles) As %Status
     quit $$$OK
 }
 
+ClassMethod GetCurrentBranch() As %String{
+    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("branch",,.errStream,.outStream,"--show-current")
+    set branchName = outStream.ReadLine(outStream.Size)
+    quit branchName
+}
+
 ClassMethod Pull(remote As %String = "origin", preview As %Boolean = 0) As %Status
 {
     #define Force 1


### PR DESCRIPTION
The new branch property in the PullEventHandler class now defaults to holding the value of the current branch before OnPull() is called.