### PR TITLE
fix: menu item names in VSCode/SMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new "Branch" parameter to `##class(SourceControl.Git.PullEventHandler)` (#351)
 - Command-line utility to do a baseline export of items in a namespace
 
+### Fixed
+- Menu items names are properly translated from internal name in VSCode, Management Portal (#372)
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -106,7 +106,6 @@ Method LocalizeName(name As %String) As %String
 
 Method OnSourceMenuItem(name As %String, ByRef Enabled As %String, ByRef DisplayName As %String, InternalName As %String) As %Status
 {
-    
     if name = "Settings" {
         set Enabled = 1
         quit $$$OK
@@ -159,6 +158,9 @@ Method OnSourceMenuItem(name As %String, ByRef Enabled As %String, ByRef Display
     } else {
         set Enabled = -1
     }
+    if (name '= "") {
+	    set DisplayName = ..LocalizeName(name)
+    }
     quit $$$OK
 }
 
@@ -186,6 +188,9 @@ Method OnSourceMenuContextItem(itemName As %String, menuItemName As %String, ByR
         set Enabled = $case(menuItemName, "AddToSC":-1,:1)
     } else {
         set Enabled = $case(menuItemName, "AddToSC":1,:-1)
+    }
+    if (menuItemName '= "") {
+	    set DisplayName = ..LocalizeName(menuItemName)
     }
     quit $$$OK
 }


### PR DESCRIPTION
Fixes #372

Turns out this was super easy - the names are right in management portal / VSCode now. Both were wrong before because both did something slightly different from what Studio did. (Menu item names are still fine there too, though.)