### PR TITLE
ignore deletions from merge, rebase, etc.

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1620,8 +1620,9 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
             else {
                 set modification.internalName = ""
             }
-            set files($increment(files)) = modification
-            set mod = files(files)
+            if modification.changeType '= "D" { // for now, do not support deletes
+                set files($increment(files)) = modification
+            }
             write !, ?4, modification.changeType, ?4, modification.internalName, ?4 , modification.externalName
         }
 


### PR DESCRIPTION
Currently we sync changes to IRIS from a merge, rebase, etc. by running diff beforehand to find the modified items. This doesn't work well if a file was added to the local branch but not pushed to the remote branch - that add is treated as a delete by the diff, which causes the item to be deleted from IRIS.
For now, we are just ignoring deletions.
In the long term, instead of using "diff" to determine modified items we will need to look at the output of merge, rebase, etc. to determine when things are actually being deleted and added.