### PR TITLE
Merge, Pull and Rebase now don't use diff to synchronize file system with IRIS

### DIFF
--- a/cls/SourceControl/Git/Util/Buffer.cls
+++ b/cls/SourceControl/Git/Util/Buffer.cls
@@ -281,3 +281,4 @@ Method UsePreviousDeviceAndSettings() [ Internal, Private ]
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1565,13 +1565,16 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
 
     set newArgs($increment(newArgs)) = command
 
-    // defining variables for if statement use later
-    set syncIris = 0
+    set syncIrisWithDiff = 0 // whether IRIS needs to be synced with repo file changes using diff output
+    set syncIrisWithCommand = 0 // // whether IRIS needs to be synced with repo file changes using command output
     set diffBase = ""
     set diffCompare = ""
     set pullOriginIndex = ""
-    if (command = "checkout") || (command = "merge") || (command = "rebase") || (command = "pull"){
-        set syncIris = 1
+    if (command = "checkout") || (command = "pull"){
+        set syncIrisWithDiff = 1
+        set diffCompare = args(args)
+    } elseif (command = "merge") || (command = "rebase") {
+        set syncIrisWithCommand = 1
         set diffCompare = args(args)
     }
     
@@ -1582,13 +1585,16 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
             if newArgs(newArgs) = pullArg {
                 set pullOriginIndex = newArgs
             }
-            if (args(i) = "checkout") || (args(i) = "merge") || (args(i) = "rebase") || (args(i) = "pull"){
-                set syncIris = 1
+            if (args(i) = "checkout") || (args(i) = "pull"){
+                set syncIrisWithDiff = 1
                 set diffCompare = args(i + 1)
                 
                 if args = (i + 2) {
                     set diffBase = args(i + 2)
                 }
+            } elseif (args(i) = "merge") || (args(i) = "rebase"){
+                set syncIrisWithCommand = 1
+                set diffCompare = args(i + 1)
             }
 
             if (args(i) = "pull") {
@@ -1597,11 +1603,12 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         }
     }
 
-    if (diffCompare = "--no-commit") || (diffCompare = "--abort") {
-        set syncIris = 0
+    if (diffCompare = "--no-commit") || (diffCompare = "--abort") || (diffCompare = "-b") {
+        set syncIrisWithDiff = 0
+        set syncIrisWithCommand = 0
     }
 
-    if syncIris {
+    if syncIrisWithDiff {
         if diffBase = "" {
             set diffBase = ..GetCurrentBranch()
         }
@@ -1621,7 +1628,6 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
                 set modification.internalName = ""
             }
             set files($increment(files)) = modification
-            set mod = files(files)
             write !, ?4, modification.changeType, ?4, modification.internalName, ?4 , modification.externalName
         }
 
@@ -1656,16 +1662,65 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     for stream=errStream,outStream {
         set stream.RemoveOnClose = 1
     }
-    do ..PrintStreams(errStream, outStream)
-    if syncIris {
-        $$$ThrowOnError(..SyncIrisWithRepo(.files))
+    // do ..PrintStreams(errStream, outStream)
+    if syncIrisWithDiff {
+        $$$ThrowOnError(..SyncIrisWithRepoThroughDiff(.files))
+    } elseif syncIrisWithCommand {
+        $$$ThrowOnError(..SyncIrisWithRepoThroughCommand(.outStream))
     }
     quit returnCode
 }
 
-ClassMethod SyncIrisWithRepo(ByRef files)
+ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
 {
+    set deletedFiles = ""
+    set addedFiles = ""
+    set files = ""
+    while (outStream.AtEnd = 0) {
 
+        set line = outStream.ReadLine()
+        set ^mtempz($i(^mtempz)) = line
+        set lineStart = $piece(line, " ", 2)
+        if (lineStart = "delete") || (lineStart = "create") {
+            set fileOperation = $select(lineStart = "create" : "A", 1: "D")
+            set externalName = $piece(line, " ", *)
+            set internalName = ##class(SourceControl.Git.Utils).NameToInternalName(externalName,,0)
+            set modification = ##class(SourceControl.Git.Modification).%New()
+            set modification.changeType = fileOperation
+            set modification.internalName = internalName
+            set modification.externalName = externalName
+            set files($i(files)) = modification
+            if fileOperation = "A" {
+                set addedFiles = addedFiles_","_internalName
+            } else {
+                set deletedFiles = deletedFiles_","_internalName
+            }
+        }
+    }
+    
+    set deletedFiles = $extract(deletedFiles, 2, *)
+    set addedFiles = $extract(addedFiles, 2, *)
+
+    set ^mtemphw("addedFiles", $i(^mtemphw("addedFiles"))) = addedFiles
+    set ^mtemphw("deletedFiles", $i(^mtemphw("deletedFiles"))) = deletedFiles
+
+    if (deletedFiles '= ""){
+        set sc = ##class(SourceControl.Git.Utils).RemoveFromServerSideSourceControl(deletedFiles)
+    }
+    if (addedFiles '= ""){
+        set sc = ##class(SourceControl.Git.Utils).AddToServerSideSourceControl(addedFiles)
+    }
+
+    do outStream.Rewind()
+    set event = $classmethod(..PullEventClass(),"%New")
+    set event.LocalRoot = ..TempFolder()
+    merge event.ModifiedFiles = files
+    quit event.OnPull()
+}
+
+ClassMethod SyncIrisWithRepoThroughDiff(ByRef files) As %Status
+{
+    set ^mtempz($i(^mtempz)) = "here"
     set key = $order(files(""))
     set deletedFiles = ""
     set addedFiles = ""
@@ -2348,3 +2403,4 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -475,7 +475,7 @@ ClassMethod Pull(remote As %String = "origin") As %Status
     set branchName = outStream.ReadLine(outStream.Size)
     write !, "Pulling from branch: ", branchName
     kill errStream, outStream
-    set returnCode = ..RunGitWithArgs(.errStream, .outStream, "pull", remote _ "/" _ branchName)
+    set returnCode = ..RunGitWithArgs(.errStream, .outStream, "pull", remote)
     
     w !, "Pull ran with return code: " _ returnCode
     quit $$$OK
@@ -1534,10 +1534,6 @@ ClassMethod RunGitCommand(command As %String, Output errStream, Output outStream
 
 ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", Output errStream, Output outStream, args...) As %Integer
 {
-    set pullArg = ""
-    if command = "pull" {
-        set pullArg = args(1)
-    }
     // Special case: git --version is used internally even when the settings incorporated here may be invalid/unspecified.
     if (command '= "--version") {
         set newArgs($increment(newArgs)) = "-C"
@@ -1569,11 +1565,11 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     set syncIrisWithCommand = 0 // // whether IRIS needs to be synced with repo file changes using command output
     set diffBase = ""
     set diffCompare = ""
-    set pullOriginIndex = ""
-    if (command = "checkout") || (command = "pull"){
+
+    if (command = "checkout"){
         set syncIrisWithDiff = 1
         set diffCompare = args(args)
-    } elseif (command = "merge") || (command = "rebase") {
+    } elseif (command = "merge") || (command = "rebase")  || (command = "pull"){
         set syncIrisWithCommand = 1
         set diffCompare = args(args)
     }
@@ -1582,24 +1578,18 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     for i=1:1:$get(args) {
         if ($data(args(i))) {
             set newArgs($increment(newArgs)) = args(i)
-            if newArgs(newArgs) = pullArg {
-                set pullOriginIndex = newArgs
-            }
-            if (args(i) = "checkout") || (args(i) = "pull"){
+            if (args(i) = "checkout") {
                 set syncIrisWithDiff = 1
                 set diffCompare = args(i + 1)
                 
                 if args = (i + 2) {
                     set diffBase = args(i + 2)
                 }
-            } elseif (args(i) = "merge") || (args(i) = "rebase"){
+            } elseif (args(i) = "merge") || (args(i) = "rebase") || (args(i) = "pull") {
                 set syncIrisWithCommand = 1
                 set diffCompare = args(i + 1)
             }
 
-            if (args(i) = "pull") {
-                set pullOriginIndex = i
-            }
         }
     }
 
@@ -1631,9 +1621,6 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
             write !, ?4, modification.changeType, ?4, modification.internalName, ?4 , modification.externalName
         }
 
-        if pullOriginIndex '= "" {
-            set newArgs(pullOriginIndex) = $piece(newArgs(pullOriginIndex), "/", 1)
-        }
     }
 
     set outLog = ##class(%Library.File).TempFilename()
@@ -1662,7 +1649,7 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     for stream=errStream,outStream {
         set stream.RemoveOnClose = 1
     }
-    // do ..PrintStreams(errStream, outStream)
+    do ..PrintStreams(errStream, outStream)
     if syncIrisWithDiff {
         $$$ThrowOnError(..SyncIrisWithRepoThroughDiff(.files))
     } elseif syncIrisWithCommand {

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1679,7 +1679,6 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
     while (outStream.AtEnd = 0) {
 
         set line = outStream.ReadLine()
-        set ^mtempz($i(^mtempz)) = line
         set lineStart = $piece(line, " ", 2)
         if (lineStart = "delete") || (lineStart = "create") {
             set fileOperation = $select(lineStart = "create" : "A", 1: "D")
@@ -1701,8 +1700,6 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
     set deletedFiles = $extract(deletedFiles, 2, *)
     set addedFiles = $extract(addedFiles, 2, *)
 
-    set ^mtemphw("addedFiles", $i(^mtemphw("addedFiles"))) = addedFiles
-    set ^mtemphw("deletedFiles", $i(^mtemphw("deletedFiles"))) = deletedFiles
 
     if (deletedFiles '= ""){
         set sc = ##class(SourceControl.Git.Utils).RemoveFromServerSideSourceControl(deletedFiles)
@@ -1720,7 +1717,6 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
 
 ClassMethod SyncIrisWithRepoThroughDiff(ByRef files) As %Status
 {
-    set ^mtempz($i(^mtempz)) = "here"
     set key = $order(files(""))
     set deletedFiles = ""
     set addedFiles = ""

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -243,3 +243,4 @@ ClassMethod GetPackageVersion() As %Library.DynamicObject
 }
 
 }
+

--- a/cls/_zpkg/isc/sc/git/Socket.cls
+++ b/cls/_zpkg/isc/sc/git/Socket.cls
@@ -15,7 +15,7 @@ ClassMethod Run()
 		set branchName = ##class(SourceControl.Git.Utils).GetCurrentBranch()
 		do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "fetch")
 		kill errStream, outStream
-		do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "diff", "origin/"_branchName, "--name-status")
+		do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "log", "HEAD..origin", "--name-status")
      } ElseIf %request.Get("method") = "pull" {
          Do ##class(SourceControl.Git.API).Pull()
      } ElseIf %request.Get("method") = "init" {


### PR DESCRIPTION
Merge, Pull and Rebase will now use the output of the command itself to drive their synchronization with IRIS. 

ex:
the merge command will output:
> Merge made by the 'ort' strategy. 
> cls/package/newb4.cls | 5 ----- 
> cls/package/newb5.cls | 5 ----- 
> cls/package/newb7.cls | 5 +++++ 
> 3 files changed, 5 insertions(+), 10 deletions(-)
> delete mode 100644 cls/package/newb4.cls 
> delete mode 100644 cls/package/newb5.cls 
> create mode 100644 cls/package/newb7.cls 

In this example, the last 3 lines of the output are used to sync iris with the filesystem
