### PR TITLE
Non read-only webUI git operations lock session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modifications to local repo files are now synced with IRIS (#153)
 - Menu items names are properly translated from internal name in VSCode, Management Portal (#372)
 - Now has proper locking behavior in `##class(SourceControl.Git.WebUIDriver).HandleRequest()`(#385)
+- Git operations from the WebUI now don't unlock the session if they aren't read-only
 
 ## [2.3.1] - 2024-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Modifications to local repo files are now synced with IRIS (#153)
 - Menu items names are properly translated from internal name in VSCode, Management Portal (#372)
+- Now has proper locking behavior in `##class(SourceControl.Git.WebUIDriver).HandleRequest()`(#385)
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -71,3 +71,4 @@ Method DeleteFile(item As %String) As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -210,3 +210,4 @@ Method OnAfterConfigure() As %Boolean
 }
 
 }
+

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -3,7 +3,6 @@ Class SourceControl.Git.WebUIDriver
 
 ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Output handled As %Boolean = 0, Output %data As %Stream.Object)
 {
-    do %session.Unlock()
     // Make sure we capture any stray output
     set buffer = ##class(SourceControl.Git.Util.Buffer).%New()
     do buffer.BeginCaptureOutput()
@@ -13,6 +12,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
     #dim %request as %CSP.Request
     set pathStart = $piece(pagePath,"/",2)
     if pathStart = "api" {
+        do %session.Unlock()
         set handled = 1
         set %data = ##class(%Stream.FileCharacter).%New()
         if $extract(pagePath,6,*) = "userinfo" {
@@ -42,6 +42,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
             SimpleHTTPRequestHandler.do_GET(self)
             */
             if (pathStart = "git") {
+                do %session.Unlock()
                 if $piece(pagePath,"/",3) = "cat-file" {
                     set blob = $piece(pagePath,"/",4)
                     set name = $Piece(pagePath,"/",*)
@@ -107,6 +108,10 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
                 }
                 set readOnlyCommands = $listbuild("branch","tag","log","ls-files","ls-tree","show","status","diff")
                 set baseCommand = $Piece(args(1)," ")
+                
+                if '$listfind(readOnlyCommands,baseCommand) {
+                    do %session.Unlock()
+                }
 
                 set gitArgs($increment(gitArgs)) = "color.ui=true"
 

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -109,7 +109,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
                 set readOnlyCommands = $listbuild("branch","tag","log","ls-files","ls-tree","show","status","diff")
                 set baseCommand = $Piece(args(1)," ")
                 
-                if '$listfind(readOnlyCommands,baseCommand) {
+                if $listfind(readOnlyCommands,baseCommand) {
                     do %session.Unlock()
                 }
 

--- a/csp/webuidriver.csp
+++ b/csp/webuidriver.csp
@@ -19,17 +19,19 @@
 	} catch e {
 		// ignore; may occur on platform versions without the above properties
 	}
-	do %session.Unlock()
+	
 
 	// Serve static content when appropriate.
 	// index.html
 	if (url = %base) || (url = $Extract(%base,1,*-1)) {
+		do %session.Unlock()
 		do %request.Set("FILE","/isc/studio/usertemplates/gitsourcecontrol/index.html")
 		set %stream = 1
 		quit 1
 	}
 	// other static resources
     if $Match(url,"^(.*/img/.*|.*\.(js|map|html|css|woff|woff2))$") {
+		do %session.Unlock()
 		do %request.Set("FILE","/isc/studio/usertemplates/gitsourcecontrol/"_$Piece(url,%base,2,*))
 		kill %base
 		set %stream = 1


### PR DESCRIPTION
Git operations from the WebUI now don't unlock the session if they aren't read-only