### PR TITLE
Fix #371 - now doesn't prompt for commit msg if no uncomitted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Modifications to local repo files are now synced with IRIS (#153)
 - Menu items names are properly translated from internal name in VSCode, Management Portal (#372)
+- Syncing only prompts users for a commit message if there are uncommitted files (#390)
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -71,3 +71,4 @@ Method DeleteFile(item As %String) As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -210,3 +210,4 @@ Method OnAfterConfigure() As %Boolean
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -253,9 +253,15 @@ ClassMethod UserAction(InternalName As %String, MenuName As %String, ByRef Targe
         set Action = 7
         quit $$$OK
     } elseif (menuItemName = "Sync") {
-        set Target = "Enter a commit message for the sync operation"
-        set Action = 7
-        set Msg = ..PreSync()
+        if ..CheckForUncommittedFiles() {
+            set Target = "Enter a commit message for the sync operation"
+            set Action = 7
+            set Msg = ..PreSync()
+        } else {
+            do ..Sync("")
+        }
+        
+        
         quit $$$OK
     } elseif (menuItemName = "Push") {
         quit ..Push()
@@ -376,15 +382,30 @@ ClassMethod PreSync() As %String
 /// Commits all the files as needed by the Sync operation 
 ClassMethod SyncCommit(Msg As %String) As %Status
 {
-    set uncommittedFilesWithAction = ##class(SourceControl.Git.Utils).UncommittedWithAction().%Get("user")
-    set username = ..GitUserName()
-    set email = ..GitUserEmail()
-    set author = username_" <"_email_">"
-    do ..RunGitWithArgs(.errStream, .outStream, "commit", "--author", author, "-m", Msg)
-    do ..PrintStreams(errStream, outStream)
-    $$$QuitOnError(..ClearUncommitted(uncommittedFilesWithAction))
-    $$$QuitOnError(##class(SourceControl.Git.Change).RefreshUncommitted(,,,1))
+   
+    if ..CheckForUncommittedFiles() {
+        set uncommittedFilesWithAction = ##class(SourceControl.Git.Utils).UncommittedWithAction().%Get("user")
+        set username = ..GitUserName()
+        set email = ..GitUserEmail()
+        set author = username_" <"_email_">"
+        do ..RunGitWithArgs(.errStream, .outStream, "commit", "--author", author, "-m", Msg)
+        do ..PrintStreams(errStream, outStream)
+        $$$QuitOnError(..ClearUncommitted(uncommittedFilesWithAction))
+        $$$QuitOnError(##class(SourceControl.Git.Change).RefreshUncommitted(,,,1))
+    }
+    
     quit $$$OK
+}
+
+ClassMethod CheckForUncommittedFiles() As %Boolean
+{
+    set uncommittedFilesWithAction = ##class(SourceControl.Git.Utils).UncommittedWithAction().%Get("user")
+    set valInArr = uncommittedFilesWithAction.%Pop()
+    if valInArr = "" {
+        return 0
+    } else {
+        quit 1
+    }
 }
 
 /// Goes through all the added files and stages them


### PR DESCRIPTION
Syncing only prompts users for a commit message if there are uncommitted files

Fixes #371 