### PR TITLE
POST requests to /git now accept all types of characters in the request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebUI works properly for users with %Developer without needing to add further SQL privileges (#365)
 - Fixed `<UNDEFINED>` error running Import All (#380)
 - Discarding changes now recompiles - critical for productions and some other cases (#387)
+- Special characters in WebUI git commands now result in the command being executed properly (#369)
 
 ## [2.3.1] - 2024-04-30
 

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -45,3 +45,4 @@ ClassMethod ForInternalNames(InternalName As %String) As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/Util/ProductionConflictResolver.cls
+++ b/cls/SourceControl/Git/Util/ProductionConflictResolver.cls
@@ -154,3 +154,4 @@ ClassMethod ResolveStream(stream As %Stream.Object)
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2464,3 +2464,4 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -91,18 +91,6 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
             if (pathStart = "git") {
                 merge data = %request.Data 
                 set args = data("command",1)
-                #; for {
-                #;     set reference = $query(@reference)
-                #;     merge ^mtempref($i(^mtempref)) = reference
-                #;     quit:reference=""
-                #;     if $qsubscript(reference,3)="O" {
-                #;         set args(@reference)=$qsubscript(reference,1)
-                #;         if $data(%request.Data($qsubscript(reference,1),$qsubscript(reference,2)),argValue)#2 && (argValue '= "") {
-                #;             set args(@reference)=args(@reference)_"="_argValue
-                #;         }
-                #;     }
-                #; }
-
                 
                 // Problem: args(1) might contain $c(10) followed by our stdin value
                 if $data(args)#2 {

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -89,25 +89,28 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
             SimpleHTTPRequestHandler.do_POST(self)
             */
             if (pathStart = "git") {
-                set reference = "%request.Data"
-                for {
-                    set reference = $query(@reference)
-                    quit:reference=""
-                    if $qsubscript(reference,3)="O" {
-                        set args(@reference)=$qsubscript(reference,1)
-                        if $data(%request.Data($qsubscript(reference,1),$qsubscript(reference,2)),argValue)#2 && (argValue '= "") {
-                            set args(@reference)=args(@reference)_"="_argValue
-                        }
-                    }
-                }
+                merge data = %request.Data 
+                set args = data("command",1)
+                #; for {
+                #;     set reference = $query(@reference)
+                #;     merge ^mtempref($i(^mtempref)) = reference
+                #;     quit:reference=""
+                #;     if $qsubscript(reference,3)="O" {
+                #;         set args(@reference)=$qsubscript(reference,1)
+                #;         if $data(%request.Data($qsubscript(reference,1),$qsubscript(reference,2)),argValue)#2 && (argValue '= "") {
+                #;             set args(@reference)=args(@reference)_"="_argValue
+                #;         }
+                #;     }
+                #; }
+
                 
                 // Problem: args(1) might contain $c(10) followed by our stdin value
-                if $data(args(1))#2 {
-                    set stdin = $piece(args(1),$char(10),2,*)
-                    set args(1) = $piece(args(1),$char(10))
+                if $data(args)#2 {
+                    set stdin = $piece(args,$char(10),2,*)
+                    set args = $piece(args,$char(10))
                 }
                 set readOnlyCommands = $listbuild("branch","tag","log","ls-files","ls-tree","show","status","diff")
-                set baseCommand = $Piece(args(1)," ")
+                set baseCommand = $Piece(args," ")
                 
                 if $listfind(readOnlyCommands,baseCommand) {
                     do %session.Unlock()
@@ -117,7 +120,7 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
 
                 // TODO: Don't be lazy! Implement shlex.split in ObjectScript.
                 // The below is just a little bit cheesy.
-                set argList = $listfromstring(args(1)," ")
+                set argList = $listfromstring(args," ")
                 set pointer = 0
                 set inQuotedString = 0
                 while $listnext(argList,pointer,arg) {

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -119,7 +119,7 @@ webui.git = function(cmd, arg1, arg2, arg3, arg4) {
         var warningCallback = arg4;
     } 
 
-    $.post("git", cmd, function(data, status, xhr) {
+    $.post("git", {command: cmd}, function(data, status, xhr) {
         if (xhr.status == 200) {
             // Convention : last lines are footer meta data like headers. An empty line marks the start if the footers
             var footers = {};

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -119,7 +119,7 @@ webui.git = function(cmd, arg1, arg2, arg3, arg4) {
         var warningCallback = arg4;
     } 
 
-    $.post("git", cmd, function(data, status, xhr) {
+    $.post("git", {command: cmd}, function(data, status, xhr) {
         if (xhr.status == 200) {
             // Convention : last lines are footer meta data like headers. An empty line marks the start if the footers
             var footers = {};


### PR DESCRIPTION
Fixes #369 

The body of post requests to /git now send the response body as {command: cmd} instead of just passing the unstructured cmd data. This allows special characters like "&" to be a part of commit messages