### PR TITLE
fix: explicitly state branch to pull

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -552,7 +552,7 @@ ClassMethod Pull(remote As %String = "origin") As %Status
     set branchName = outStream.ReadLine(outStream.Size)
     write !, "Pulling from branch: ", branchName
     kill errStream, outStream
-    set returnCode = ..RunGitWithArgs(.errStream, .outStream, "pull", remote)
+    set returnCode = ..RunGitWithArgs(.errStream, .outStream, "pull", remote, branchName)
     
     w !, "Pull ran with return code: " _ returnCode
     quit $$$OK


### PR DESCRIPTION
This is needed if you're not pulling the default branch (which may commonly be the case)