### PR TITLE
Fix JavaScript errors in Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - Unreleased
+
+### Fixed
+- Fixed JS errors in Studio on certain operations (#416)
 
 ## [2.4.0] - 2024-07-08
 

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -93,7 +93,7 @@ webui.showWarning = function(message) {
     // convert links in message into actual html links
     var messageAsArr = message.split(" ");
     messageAsArr = messageAsArr.map(function(messagePart){
-        if (messagePart.startsWith("https://")) {
+        if (messagePart.substring(0,8) === "https://") {
             return '<a href="' + messagePart + '" target="_blank">' + messagePart + '</a>';
         } else {
             return messagePart;

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -93,7 +93,7 @@ webui.showWarning = function(message) {
     // convert links in message into actual html links
     var messageAsArr = message.split(" ");
     messageAsArr = messageAsArr.map(function(messagePart){
-        if (messagePart.startsWith("https://")) {
+        if (messagePart.substring(0,8) === "https://") {
             return '<a href="' + messagePart + '" target="_blank">' + messagePart + '</a>';
         } else {
             return messagePart;

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="git-source-control.ZPM">
     <Module>
       <Name>git-source-control</Name>
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
       <Description>Server-side source control extension for use of Git on InterSystems platforms</Description>
       <Keywords>git source control studio vscode</Keywords>
       <Packaging>module</Packaging>


### PR DESCRIPTION
Use 'substring' instead of 'startsWith' to prevent errors in Studio when performing actions such as refreshing remotes.

'startsWith' is not supported by Internet Explorer.