### PR TITLE
Fix bugs pertaining to adding files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed JS errors in Studio on certain operations (#416)
+- Files are added to source control upon creation properly (#404)
+- Files show in uncommitted queue when automatically added (#407)
 
 ## [2.4.0] - 2024-07-08
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -672,9 +672,10 @@ ClassMethod AddToSourceControl(InternalName As %String) As %Status
             do ..RunGitCommand("add",.errStream,.outStream,filenames(i),"--intent-to-add")
             write !, "Added ", FileInternalName, " to source control."
             do ..PrintStreams(outStream, errStream)
-            do ##class(SourceControl.Git.Change).RefreshUncommitted(,,,1)
+            
         }
     }
+    do ##class(SourceControl.Git.Change).RefreshUncommitted(,,,1)
     quit ec
 }
 
@@ -2545,3 +2546,4 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -672,6 +672,7 @@ ClassMethod AddToSourceControl(InternalName As %String) As %Status
             do ..RunGitCommand("add",.errStream,.outStream,filenames(i),"--intent-to-add")
             write !, "Added ", FileInternalName, " to source control."
             do ..PrintStreams(outStream, errStream)
+            do ##class(SourceControl.Git.Change).RefreshUncommitted(,,,1)
         }
     }
     quit ec
@@ -2544,4 +2545,3 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 }
-


### PR DESCRIPTION
Fixes #404
Fixes #407

Files are auto added to source control (and not staged) and show in the uncommitted queue. This ends up resolving #404 and #407 in one fix.