### PR TITLE
Fixed workspace list and diff of files with spaces in names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed JS errors in Studio on certain operations (#416)
+- WebUI workspace view now works properly for filenames with spaces (#423)
 
 ## [2.4.0] - 2024-07-08
 

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -1304,11 +1304,11 @@ webui.DiffView = function(sideBySide, hunkSelectionAllowed, parent, stashedCommi
                 right.webuiPrevScrollTop = 0;
                 right.webuiPrevScrollLeft = 0;
             }
-            webui.git("ls-files "+file, function(path){
-                self.gitFile = file;
+            webui.git("ls-files \""+file+"\"", function(path){
+                self.gitFile = "\"" + file + "\"";
                 self.noIndex = ""
                 if(path.length == 0 && file != undefined){
-                    self.gitFile = " /dev/null " + file;
+                    self.gitFile = " /dev/null " + "\"" + file + "\"";
                     self.noIndex = " --no-index "
                 }
                 if (self.gitCmd) {
@@ -2224,6 +2224,7 @@ webui.NewChangedFilesView = function(workspaceView) {
                     } else {
                         model = line;
                     }
+                    model = model.replace(/^"(.*)"$/g,'$1');
 
                     ++self.filesCount;
                     var isForCurrentUser;

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -1304,11 +1304,11 @@ webui.DiffView = function(sideBySide, hunkSelectionAllowed, parent, stashedCommi
                 right.webuiPrevScrollTop = 0;
                 right.webuiPrevScrollLeft = 0;
             }
-            webui.git("ls-files "+file, function(path){
-                self.gitFile = file;
+            webui.git("ls-files \""+file+"\"", function(path){
+                self.gitFile = "\"" + file + "\"";
                 self.noIndex = ""
                 if(path.length == 0 && file != undefined){
-                    self.gitFile = " /dev/null " + file;
+                    self.gitFile = " /dev/null " + "\"" + file + "\"";
                     self.noIndex = " --no-index "
                 }
                 if (self.gitCmd) {
@@ -2224,6 +2224,7 @@ webui.NewChangedFilesView = function(workspaceView) {
                     } else {
                         model = line;
                     }
+                    model = model.replace(/^"(.*)"$/g,'$1');
 
                     ++self.filesCount;
                     var isForCurrentUser;


### PR DESCRIPTION
Fixes #423 
Git status wraps filenames with spaces in quotation marks, which had been breaking parts of the workspace view.