### PR TITLE
Fix pull preview when not on main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed pull event handler handling of extremely long class names from diff (#467)
 - Fixed Git web UI prompt to update file list when file selected/unselected (#478)
 - Fixed folder settings in mappings to be saved and persist (#483)
+- Preview on the pull.csp page now shows commits from the correct branch (#490)
 
 ## [2.4.1] - 2024-08-02
 

--- a/cls/_zpkg/isc/sc/git/Socket.cls
+++ b/cls/_zpkg/isc/sc/git/Socket.cls
@@ -16,7 +16,7 @@ ClassMethod Run()
 		Write !,"Current branch: ",branchName
 		Do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "fetch")
 		Kill errStream, outStream
-		Do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "log", "HEAD..origin", "--name-status")
+		Do ##class(SourceControl.Git.Utils).RunGitWithArgs(.errStream, .outStream, "log", "HEAD..origin/"_branchName, "--name-status")
 		Do ##class(SourceControl.Git.Utils).PrintStreams(errStream, outStream)
 		If (outStream.Size = 0) && (errStream.Size = 0) {
 			Write !,"Already up to date."


### PR DESCRIPTION
Fixes an issue where the preview on the pull page would diff the current branch against the remote of the main branch, not the remote of the current branch.