### PR TITLE
Rebasing from remote loads code changed on the remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - Files in uncommitted queue in any namespace warn users when opened except for in VSCode (#370)
-
-### Added
 - Added link back to IRIS management portal from Settings, Git WebUI pages (#449)
 
 ### Fixed
 - Changed prompts in configure from 0/1 to no/yes (#461)
 - Added warnings when user is using incompatible git version (#488)
 - Fixed the back button navigation between WebUI and Settings page (#361)
+- Basic mode Sync operation now imports items changed on the remote merge branch (#506)
 
 ## [2.5.0] - 2024-09-24
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -440,7 +440,7 @@ ClassMethod MergeDefaultRemoteBranch(Output alert As %String = "") As %Boolean
         do ..RunGitWithArgs(.errStream, .outStream, "fetch", "origin", defaultMergeBranch_":"_defaultMergeBranch)
         do ..PrintStreams(errStream, outStream)
 
-        do ..RunGitWithArgs(,.outStream, "rev-parse", defaultMergeBranch)
+        do ..RunGitWithArgs(,.outStream, "rev-parse", "HEAD")
         set startSha = outStream.ReadLine()
 
         // Start a transaction so code changes can be rolled back
@@ -2693,4 +2693,3 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 }
-


### PR DESCRIPTION
Fixes #503 
We now diff the old head with the new head. Before we diffed the remote branch with the new head, which misses all the changes made on the remote branch.