### PR TITLE
After a fetch perform a diff against the remote of the current branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added warnings when user is using incompatible git version (#488)
 - Fixed the back button navigation between WebUI and Settings page (#361)
 - Basic mode Sync operation now imports items changed on the remote merge branch (#506)
+- Fetch diff output uses correct remote branch (#509)
 
 ## [2.5.0] - 2024-09-24
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -534,7 +534,7 @@ ClassMethod Fetch(ByRef diffFiles) As %Status
     do ..RunGitCommand("fetch", .errStream, .outStream)
     write !, "Fetch done"
     kill errStream, outStream
-    do ..RunGitCommand("diff", .errStream, .outStream, "..origin", "--name-only")
+    do ..RunGitCommand("diff", .errStream, .outStream, "..origin/"_..GetCurrentBranch(), "--name-only")
     set diffFiles = ""
     while (outStream.AtEnd = 0) {
         set diffFiles = diffFiles_$listbuild(outStream.ReadLine())


### PR DESCRIPTION
After performing a fetch I almost always get an unexpected and seemingly incorrect list of changed files.

The diff is being done with ```..origin``` specifed however (at least on my setup) this only ever results in the diff being done against the main branch and not the remote for the branch that I am actually on, which would be for example a feature branch that was branched from another non-main branch.

Unless I am misunderstanding what the intended result of this diff output is then it seems as though the current branch name should be specified too, for example ```..origin/foo/feature1``` so that the diff is comparing the local ```foo/feature1``` branch with the corresponding remote, this is the diff output that I would expect to see.

git version 2.34.1
IRIS for UNIX (Ubuntu Server LTS for x86-64 Containers) 2024.1 (Build 267_2U) Tue Apr 30 2024 16:04:37 EDT