### PR TITLE
Improve handling of truncated class names from git pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the back button navigation between WebUI and Settings page (#361)
 - Basic mode Sync operation now imports items changed on the remote merge branch (#506)
 - Fetch diff output uses correct remote branch (#509)
+- Properly handle more cases of truncated filenames from git pull (#511)
 
 ## [2.5.0] - 2024-09-24
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1900,10 +1900,22 @@ ClassMethod ExpandClasses(externalName As %String) As %List
     set internalName = $Piece(externalName,".",1,*-1)
     set internalName = $Extract(internalName,4,*)
     set internalName = $Translate(internalName,"/\%",".."_..PercentClassReplace())
-    &sql(select %DLIST(Name) into :classes from %Dictionary.ClassDefinition where Name like '%'||:internalName)
-    if (SQLCODE < 0) {
-        Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
-    }
+    do {
+        &sql(select %DLIST(Name) into :classes from %Dictionary.ClassDefinition where Name like '%'||:internalName)
+        if (SQLCODE < 0) {
+            Throw ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE,%msg)
+        }
+        
+        // If nothing was found then remove period-delimited pieces from the start of internalName
+        // until we either find something or run out of pieces.
+        // This will allow for classes to potentially still be identified when the
+        // repository directory structure does not align with class packages.
+        if ($ListLength(classes) = 0) {
+            set internalName = $Piece(internalName,".",2,*)
+        } else {
+            set internalName = ""
+        }
+    } while (internalName '= "")
     quit classes
 }
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1859,13 +1859,18 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
                 // In other cases, we'll just end up logging the invalid externalName.
                 if $Piece(externalName,".",*) = "cls" {
                     set possibleClasses = ..ExpandClasses(externalName)
-                    set pointer = 0
-                    while $ListNext(possibleClasses,pointer,class) {
-                        set modification = ##class(SourceControl.Git.Modification).%New()
-                        set modification.changeType = "C"
-                        set modification.internalName = class_".CLS"
-                        set modification.externalName = ..ExternalName(modification.internalName)
-                        set files($i(files)) = modification
+                    if $ListLength(possibleClasses) '= 0 {
+                        set pointer = 0
+                        while $ListNext(possibleClasses,pointer,class) {
+                            set modification = ##class(SourceControl.Git.Modification).%New()
+                            set modification.changeType = "C"
+                            set modification.internalName = class_".CLS"
+                            set modification.externalName = ..ExternalName(modification.internalName)
+                            set files($i(files)) = modification
+                        }
+                    } else {
+                        write !,"WARNING: unable to translate external name ",externalName
+                        continue
                     }
                 } else {
                     write !,"WARNING: unable to translate external name ",externalName


### PR DESCRIPTION
The current way of handling truncated class names from git pull seems to have two major flaws:
1. It is possible for truncated class names to fail to be expanded if the repository directory structure does not align with class packages
2. When this failure occurs and no possible classes are found, there is no warning generated

For example if the repository has the following base directory structure:
```/foo/bar/``` and contains class ```A.B.C``` stored on disk as ```A/B/C.cls``` (where foo and bar have no relation to any class package names)

then git pull may provide truncated output such as the following:
```.../bar/A/B/C.cls```

```ExpandClasses``` will try and fail to find a class named ```bar.A.B.C``` with no warning generated, the class silently fails to import.

```ExpandClasses``` has been updated so that upon failing to find any class names it will remove period-delimited pieces from the start of the name and try again, until it finds something or runs out of pieces.

This would mean for example that after failing to find ```bar.A.B.C``` it would then try ```A.B.C``` and find the intended class