### PR TITLE
When performing a pull, sync IRIS with repository changes using diff output rather than command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fetch diff output uses correct remote branch (#509)
 - Properly handle more cases of truncated filenames from git pull (#511)
 - Made git-source-control backwards compatible with IRIS 2021.1 (#513)
+- Sync, pull properly handle more change edge cases for import (#517, #496)
 
 ## [2.5.0] - 2024-09-24
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -447,8 +447,7 @@ ClassMethod MergeDefaultRemoteBranch(Output alert As %String = "") As %Boolean
         do ..RunGitWithArgs(.errStream, .outStream, "fetch", "origin", defaultMergeBranch_":"_defaultMergeBranch)
         do ..PrintStreams(errStream, outStream)
 
-        do ..RunGitWithArgs(,.outStream, "rev-parse", "HEAD")
-        set startSha = outStream.ReadLine()
+        set startSha = ..GetCurrentRevision()
 
         // Start a transaction so code changes can be rolled back
         set initTLevel = $TLevel
@@ -554,6 +553,13 @@ ClassMethod GetCurrentBranch() As %String
     do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("branch",,.errStream,.outStream,"--show-current")
     set branchName = outStream.ReadLine(outStream.Size)
     quit branchName
+}
+
+ClassMethod GetCurrentRevision() As %String
+{
+    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("rev-parse",,.errStream,.outStream,"HEAD")
+    set revision = outStream.ReadLine(outStream.Size)
+    quit revision
 }
 
 ClassMethod Pull(remote As %String = "origin") As %Status

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1809,20 +1809,20 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     set outLog = ##class(%Library.File).TempFilename()
     set errLog = ##class(%Library.File).TempFilename()
 
-    set command = $extract(..GitBinPath(),2,*-1)
+    set gitCommand = $extract(..GitBinPath(),2,*-1)
     
     set baseArgs = "/STDOUT="_$$$QUOTE(outLog)_" /STDERR="_$$$QUOTE(errLog)_$case(inFile, "":"", :" /STDIN="_$$$QUOTE(inFile))
     try {
         // Inject instance manager directory as global git config home directory
         // On Linux, this avoids trying to use /root/.config/git/attributes for global git config
         set env("XDG_CONFIG_HOME") = ##class(%File).ManagerDirectory()
-        set returnCode = $zf(-100,"/ENV=env... "_baseArgs,command,newArgs...)
+        set returnCode = $zf(-100,"/ENV=env... "_baseArgs,gitCommand,newArgs...)
     } catch e {
         if $$$isWINDOWS {
-            set returnCode = $zf(-100,baseArgs,command,newArgs...)
+            set returnCode = $zf(-100,baseArgs,gitCommand,newArgs...)
         } else {
             // If can't inject XDG_CONFIG_HOME (older IRIS version), need /SHELL on Linux to avoid permissions errors trying to use root's config
-            set returnCode = $zf(-100,"/SHELL "_baseArgs,command,newArgs...)
+            set returnCode = $zf(-100,"/SHELL "_baseArgs,gitCommand,newArgs...)
         }
     }
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1737,7 +1737,11 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     } elseif (command = "restore") {
         // Leave diffCompare empty, this actually does the right thing.
         set syncIrisWithDiff = 1
-    } elseif (command = "merge") || (command = "rebase")  || (command = "pull") {
+    } elseif (command = "pull") {
+        set syncIrisWithDiff = 1
+        // The current revision, prior to the pull, will be compared against
+        set diffCompare = ..GetCurrentRevision()
+    } elseif (command = "merge") || (command = "rebase") {
         set syncIrisWithCommand = 1
         if $data(args) && $data(args(args),diffCompare) {
             // no-op
@@ -1801,7 +1805,10 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         set syncIrisWithCommand = 0
     }
 
-    if syncIrisWithDiff {
+    // If performing a pull don't perform a diff until after the pull has occured.
+    // This is to avoid a double fetch, as pull performs one for us and also to avoid a potential
+    // race condition if the remote changes between now and the pull actually being performed.
+    if syncIrisWithDiff && (command '= "pull") {
         if diffBase = "" {
             set diffBase = ..GetCurrentBranch()
         }
@@ -1830,6 +1837,13 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
             // If can't inject XDG_CONFIG_HOME (older IRIS version), need /SHELL on Linux to avoid permissions errors trying to use root's config
             set returnCode = $zf(-100,"/SHELL "_baseArgs,gitCommand,newArgs...)
         }
+    }
+
+    // If performing a pull then do a diff now after the pull has occured.
+    if syncIrisWithDiff && (command = "pull") {
+        do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errorStream,.outputStream, diffCompare, "--name-status")
+        // Verbose output should not be required as pull already outputs a summary
+        do ..ParseDiffStream(outputStream,0,.files)
     }
 
     set errStream = ##class(%Stream.FileCharacter).%OpenId(errLog,,.sc)


### PR DESCRIPTION
This is intended as a hopefully superior and simpler alternative to #515 to address the same issue, though only for git pull for now. Files are not always able to be reliably imported when their names are truncated in the git pull stats summary.

The truncated git pull stat summary output is no longer used and diff output is used instead. This should allow all file types to be handled without requiring any new or custom IRIS logic. The diff is performed after the git pull to avoid a potential double fetch and also a potential race condition if the remote changes between the diff and pull taking place.

Also indirectly addresses, for pulls only, the following likely unreported/unknown issues associated with the truncated name expansion logic that I have discovered in recent days, by no longer using that logic:
- Generated classes are no longer inappropriately considered as possible classes
- Lookup tables containing spaces in their names (e.g. ```A B C.lut```) are now able to be successfully imported. Other files where this is possible may be similarly improved.

Have tested the following scenarios locally and seems to work well:
- Expert mode git pull
- Basic mode sync
- Pull from within interoperability production
- Pull using pull.csp

Have not made changes to the WebUI related logic in ```RunGitCommandWithInput``` as there did not seem to currently be any actual uses of it for pulls.

Nothing has been done for **rebase** as it appears to only be used within the context of ```MergeDefaultRemoteBranch``` which already performs a similar diff after the rebase takes place and does not seem to be affected by the same importing issues.

Nothing has been done for **merge** which may be affected by the same import issue. It appears that it is only used from WebUI but is not a feature that I have ever actually used so have not spent much time looking into it.