### PR TITLE
fix: actually include branch in status menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properly handle more cases of truncated filenames from git pull (#511)
 - Made git-source-control backwards compatible with IRIS 2021.1 (#513)
 - Sync, pull properly handle more change edge cases for import (#517, #496)
+- "Status" menu item actually includes branch when IRIS version allows (#472)
 
 ## [2.5.0] - 2024-09-24
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -194,7 +194,7 @@ Method OnSourceMenuItem(name As %String, ByRef Enabled As %String, ByRef Display
 
     if (name = "Status") {
         set DisplayName = ..LocalizeName(name)_" (branch: "_##class(SourceControl.Git.Utils).GetCurrentBranch()_")"
-    } if (name '= "") {
+    } elseif (name '= "") {
 	    set DisplayName = ..LocalizeName(name)
     }
     quit $$$OK


### PR DESCRIPTION
Calling this a bug fix because allegedly it already worked (though it didn't really)

Fixes #472 the best we can with current IRIS tooling - the menu now looks like:
![image](https://github.com/user-attachments/assets/5c28b7f5-f4df-466e-a814-6fd3ff0457fe)

(note: this requires BES248 / DP-432719 which doesn't go too far back)