### PR TITLE
Add an option to allow git push --force to be performed in expert mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - Unreleased
+
+### Added
+- Added 'git push --force' in expert mode (#527)
+
 ## [2.6.0] - 2024-10-07
 
 ### Added

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -22,6 +22,7 @@ XData Menu
 <MenuItem Separator="true"/>
 <MenuItem Name="Sync" />
 <MenuItem Name="Push" />
+<MenuItem Name="PushForce" />
 <MenuItem Name="Fetch" />
 <MenuItem Name="Pull" />
 <MenuItem Separator="true"/>
@@ -127,6 +128,7 @@ Method LocalizeName(name As %String) As %String
         "Commit":$$$Text("@Commit@Commit changes to file"),
         "Sync":$$$Text("@Sync@Sync"),
         "Push":$$$Text("@Push@Push to remote branch"),
+        "PushForce":$$$Text("@PushForce@Push to remote branch (Force)"),
         "Fetch":$$$Text("@Fetch@Fetch from remote"),
         "Pull":$$$Text("@Pull@Pull changes from remote branch"),
         "Status": $$$Text("@Status@Status"),
@@ -174,6 +176,7 @@ Method OnSourceMenuItem(name As %String, ByRef Enabled As %String, ByRef Display
                 "NewBranch": 1,
                 "SwitchBranch": 1,
                 "Push": 1,
+                "PushForce": 1,
                 "Fetch": 1,
                 "Pull": 1,
                 "Sync": -1,

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -272,6 +272,10 @@ ClassMethod UserAction(InternalName As %String, MenuName As %String, ByRef Targe
         quit $$$OK
     } elseif (menuItemName = "Push") {
         quit ..Push()
+    } elseif (menuItemName = "PushForce") {
+        set Target = "Force pushing is potentially destructive and may overwrite the commit history of the remote branch. Are you sure you want to proceed?"
+        set Action = 1 // Make sure the user confirms that they want to do this
+        quit $$$OK
     } elseif (menuItemName = "Fetch") {
         $$$QuitOnError(..Fetch(.diffFiles))
         set pointer = 0
@@ -319,6 +323,11 @@ ClassMethod AfterUserAction(Type As %Integer, Name As %String, InternalName As %
     } elseif (menuItemName = "Sync") {
         if (Answer = 1) {
             do ..Sync(Msg)
+            set Reload = 1
+        }
+    } elseif (menuItemName = "PushForce") {
+        if (Answer = 1) {
+            do ..Push(,1)
             set Reload = 1
         }
     } elseif (menuItemName = "GitWebUI") {

--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -20,6 +20,8 @@ This menu option is analogous to the [git add](https://git-scm.com/docs/git-add)
 This menu option will only appear if the currently open file has been already added using the 'Add' menu option. It undoes the effect of adding the file, similar to running [git reset](https://git-scm.com/docs/git-reset) on a specific file.
 ## Push to remote branch
 This option pushes the commits in the branch to the remote repository. This exhibits the same behavior as the [git push](https://git-scm.com/docs/git-push) command.
+## Push to remote branch (force)
+This option forcibly pushes the commits in the branch to the remote repository. This is potentially destructive and may overwrite the commit history of the remote branch. This exhibits the same behavior as the [git push --force](https://git-scm.com/docs/git-push) command.
 ## Fetch from remote
 Much like the [git fetch](https://git-scm.com/docs/git-fetch) command, this option fetches the most recent versions of the branch without merging that version into the local copy of the branch.
 ## Pull changes from remote branch

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="git-source-control.ZPM">
     <Module>
       <Name>git-source-control</Name>
-      <Version>2.6.0</Version>
+      <Version>2.7.0</Version>
       <Description>Server-side source control extension for use of Git on InterSystems platforms</Description>
       <Keywords>git source control studio vscode</Keywords>
       <Packaging>module</Packaging>


### PR DESCRIPTION
Add **Push to remote branch (Force)** to the menu, allowing an expert mode user to perform ```git push --force```

The user is prompted with a warning and to confirm that they want to do this.

The motivation for this is that a basic mode user is capable of indirectly performing a force push via the **Sync** option, potentially without even realising or understanding that they are doing so. An expert mode user should be able to do the same with intent but currently has no option available outside of manually interacting with the local repository.