### PR TITLE
Fixed checking out non-existent branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added feedback to settings page (#550)
 - Fix "Home" navigation to point to current namespace (#548)
 - Fixed issues when user checks out nonexistent branch (#549)
+- Fixed checking out branch with uncommitted work (#539)
 
 ## [2.6.0] - 2024-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed git path configuration (#463)
 - Added feedback to settings page (#550)
 - Fix "Home" navigation to point to current namespace (#548)
+- Fixed issues when user checks out nonexistent branch (#549)
 
 ## [2.6.0] - 2024-10-07
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -327,7 +327,10 @@ ClassMethod AfterUserAction(Type As %Integer, Name As %String, InternalName As %
         }
     } elseif (menuItemName = "SwitchBranch") {
         if (Answer = 1) {
-            do ..SwitchBranch(Msg)
+            set status = ..SwitchBranch(Msg)
+            if $$$ISERR(status) {
+                Quit status
+            }
             set Reload = 1
         }
     } elseif (menuItemName = "Sync") {
@@ -400,6 +403,13 @@ ClassMethod NewBranch(newBranchName As %String) As %Status
 
 ClassMethod SwitchBranch(targetBranchName As %String) As %Status
 {
+    // Make sure that branch exists first
+    do ..RunGitWithArgs(.errStream,.outStream,"local-branches","branch", "--verbose")
+    set branches = outStream.Read()
+    if ('$find(branches,targetBranchName)) {
+        quit $$$ERROR($$$GeneralError, "Branch does not exist")
+    }
+    k outStream, errStream
     do ..RunGitWithArgs(.errStream, .outStream, "checkout", targetBranchName)
     do ..PrintStreams(errStream, outStream)
     quit $$$OK

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -403,8 +403,8 @@ ClassMethod NewBranch(newBranchName As %String) As %Status
 
 ClassMethod SwitchBranch(targetBranchName As %String) As %Status
 {
-    // Make sure that branch exists first
-    do ..RunGitWithArgs(.errStream,.outStream,"local-branches","branch", "--verbose")
+    // Make sure that branch exists first (-a lists both local and remote)
+    do ..RunGitWithArgs(.errStream,.outStream,"branch", "-a")
     set branches = outStream.Read()
     if ('$find(branches,targetBranchName)) {
         quit $$$ERROR($$$GeneralError, "Selected branch does not exist"_$C(10))
@@ -412,6 +412,11 @@ ClassMethod SwitchBranch(targetBranchName As %String) As %Status
     k outStream, errStream
     do ..RunGitWithArgs(.errStream, .outStream, "checkout", targetBranchName)
     do ..PrintStreams(errStream, outStream)
+    // Checkout can fail due to unstaged changes
+    set errs = errStream.Read()
+    if (errs '= "") {
+        quit $$$ERROR($$$GeneralError, errs)
+    }
     quit $$$OK
 }
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -407,7 +407,7 @@ ClassMethod SwitchBranch(targetBranchName As %String) As %Status
     do ..RunGitWithArgs(.errStream,.outStream,"local-branches","branch", "--verbose")
     set branches = outStream.Read()
     if ('$find(branches,targetBranchName)) {
-        quit $$$ERROR($$$GeneralError, "Branch does not exist")
+        quit $$$ERROR($$$GeneralError, "Selected branch does not exist"_$C(10))
     }
     k outStream, errStream
     do ..RunGitWithArgs(.errStream, .outStream, "checkout", targetBranchName)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -414,7 +414,7 @@ ClassMethod SwitchBranch(targetBranchName As %String) As %Status
     do ..PrintStreams(errStream, outStream)
     // Checkout can fail due to unstaged changes
     set errs = errStream.Read()
-    if (errs '= "") {
+    if ($find(errs, "error")) {
         quit $$$ERROR($$$GeneralError, errs)
     }
     quit $$$OK


### PR DESCRIPTION
Fixes #549, #539

@isc-tleavitt Right now this throws an error (so that user is aware that checkout failed). Is there a better way to show an alert on the management portal / vscode / studio? (This happens on "AfterUserAction" so we have no access to the "Target" functionality of %Studio.SourceControl.Base.

