### PR TITLE
Clarify documentation about adding items to source control

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The same right click menus as in Studio live under "Server Source Control..." wh
 
 Note: Studio has been deprecated. VSCode is the IDE recommended by InterSystems.
 
-Add a file for tracking by right-clicking on it in the workspace/project view and choosing Git &gt; Add.
+Add an existing file for tracking by right-clicking on it in the workspace/project view and choosing Git &gt; Add.
 This same menu also has options to remove (stop tracking the file), discard changes (revert to the index), or commit changes.
 
 You can browse file history and commit changes through a user interface launched from the top level Git > "Launch Git UI" menu item. There is also a page for configuring settings.

--- a/docs/hcc.md
+++ b/docs/hcc.md
@@ -16,7 +16,7 @@ You will be prompted to enter a name for your new branch (no spaces or special c
 
 ### Making Changes
 
-Now that you are in your new branch (you can see your current branch in the first item in the source control menu), you can start making changes. As you make changes to different business processes, rules, and productions, make sure that all of these changes are saved properly and any new items are added to source control (via the "Add" menu item) before you continue to sync and merge.
+Now that you are in your new branch (you can see your current branch in the first item in the source control menu), you can start making changes. As you make changes to different business processes, rules, and productions, make sure that all of these changes are saved properly before you continue to sync and merge.
 
 ### Syncing and Merge Requests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ The following is a testing plan that should be followed prior to release of a ne
 - Use VS Code to create a new class. Use the Source Control menu to Import All from the repository. Check the output to confirm that the contents of the repository were imported and compiled.
 - Test changing Git project settings in a web browser and in Studio. Input labels and tooltips should describe each setting.
 - In Expert Mode, test:
-  - Add a new item through Studio / VS Code. Use the Add option in the Source Control Menu. The item should show up in the Workspace view of the WebUI.
+  - Add a new item through Studio / VS Code. View the Source Control Menu - there should be an option to remove it from source control. The item should show up in the Workspace view of the WebUI.
   - Stash the item in the WebUI. It should be deleted from IRIS. Pop it from the stash. It should be imported and compiled. Discard the item in the WebUI. It should be deleted from IRIS.
   - Add, delete, and modify some items in Studio / VS Code. Commit through the WebUI with a commit message and details. The commit should show with the expected commit message and differences in the branch view.
   - Select the branch in the branch view and click "Push Branch". It should successfully push changes to the remote repository.


### PR DESCRIPTION
Resolves #489 
This commit changed the behavior so that when a new item is created in IRIS, it is automatically added to source control: https://github.com/intersystems/git-source-control/commit/212b988190e5df2326bd9bcbb99bd70f36b32c00

I don't think this needs to be called out explicitly in documentation at this point, but I've updated the testing plan to reflect it and made some tweaks to the wording in the other documentation.