### PR TITLE
Workspace view displays filenames with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Production configuration page no longer closes Sync/WebUI when operations there change the production (#542)
 - Remove leading/trailing spaces from input to Configure() (#356)
 - Fix branches with special characters not showing in GitUI (#523)
+- Fix filenames with spaces not showing correctly in workspace view (#551)
 
 ## [2.6.0] - 2024-10-07
 

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -2560,16 +2560,10 @@ webui.NewChangedFilesView = function(workspaceView) {
                     } else {
                         model = line;
                     }
-                    model = model.replace(/^"(.*)"$/g,'$1');
+                    model = model.replace(/^"(.*)"$/g,'$1').trim();
 
                     ++self.filesCount;
-                    var isForCurrentUser;
-                    if(model.indexOf(" ") > -1){
-                        isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
-                    } else {
-                        isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
-                    }
-                    
+                    var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
                     if (isForCurrentUser) {
                         addItemToFileList(fileList, indexStatus, workingTreeStatus, model, false);
                     } else {

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -2560,16 +2560,10 @@ webui.NewChangedFilesView = function(workspaceView) {
                     } else {
                         model = line;
                     }
-                    model = model.replace(/^"(.*)"$/g,'$1');
+                    model = model.replace(/^"(.*)"$/g,'$1').trim();
 
                     ++self.filesCount;
-                    var isForCurrentUser;
-                    if(model.indexOf(" ") > -1){
-                        isForCurrentUser = (uncommittedItems.indexOf(model.substring(1, model.length-1)) > -1);
-                    } else {
-                        isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
-                    }
-                    
+                    var isForCurrentUser = (uncommittedItems.indexOf(model) > -1);
                     if (isForCurrentUser) {
                         addItemToFileList(fileList, indexStatus, workingTreeStatus, model, false);
                     } else {


### PR DESCRIPTION
Fixes #551 
Files with spaces now display the "item edited by another user" icon properly. Tested in Studio.