### PR TITLE
Placeholder text on commit input no longer promises a length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Production configuration page no longer closes Sync/WebUI when operations there change the production (#542)
 - Remove leading/trailing spaces from input to Configure() (#356)
 - Fix branches with special characters not showing in GitUI (#523)
+- Removed inaccurate placeholder text for commit message in UI (#406)
 
 ## [2.6.0] - 2024-10-07
 

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -3047,7 +3047,7 @@ webui.NewChangedFilesView = function(workspaceView) {
                 '</div>' +
                 '<div class="commit-area col-sm-6">' +
                     '<div class="form-group">' +
-                        '<input type="area" class="form-control" id="commitMsg" placeholder="Enter commit message (required, 72 character limit)">' +
+                        '<input type="area" class="form-control" id="commitMsg" placeholder="Enter commit message (required)">' +
                     '</div>' +
                     '<div class="form-group">' +
                         '<textarea class="form-control" id="commitMsgDetail" rows="4" placeholder="Enter commit details (optional)"></textarea>' +

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -3047,7 +3047,7 @@ webui.NewChangedFilesView = function(workspaceView) {
                 '</div>' +
                 '<div class="commit-area col-sm-6">' +
                     '<div class="form-group">' +
-                        '<input type="area" class="form-control" id="commitMsg" placeholder="Enter commit message (required, 72 character limit)">' +
+                        '<input type="area" class="form-control" id="commitMsg" placeholder="Enter commit message (required)">' +
                     '</div>' +
                     '<div class="form-group">' +
                         '<textarea class="form-control" id="commitMsgDetail" rows="4" placeholder="Enter commit details (optional)"></textarea>' +


### PR DESCRIPTION
Fixes #406 
This just removes the inaccurate placeholder text about the limit instead of actually enforcing a limit. I feel the commit input being a single line instead of a textarea is enough of a nudge that a commit message should be short and sweet.