### PR TITLE
fix: logging issues

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -612,7 +612,7 @@ ClassMethod GetCurrentRevision() As %String
     quit revision
 }
 
-ClassMethod Pull(remote As %String = "origin", pTerminateOnError As %Boolean=0) As %Status
+ClassMethod Pull(remote As %String = "origin", pTerminateOnError As %Boolean = 0) As %Status
 {
     New %gitSCOutputFlag
     Set %gitSCOutputFlag = 1
@@ -1924,7 +1924,9 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     }
 
     if syncIrisWithDiff {
-        do ..PrintStreams(errStream, outStream)
+        if '$data(%gitSCOutputFlag)#2 {
+            do ..PrintStreams(errStream, outStream)
+        }
         set buffer = ##class(SourceControl.Git.Util.Buffer).%New()
         do buffer.BeginCaptureOutput()
         set st = ..SyncIrisWithRepoThroughDiff(.files, .filterToFiles, invert)
@@ -2066,6 +2068,8 @@ ClassMethod ParseDiffStream(stream As %Stream.Object, verbose As %Boolean = 1, O
     kill files
     while (stream.AtEnd = 0) {
         set file = stream.ReadLine()
+        continue:file=""
+
         set modification = ##class(SourceControl.Git.Modification).%New()
         set modification.changeType = $piece(file, $c(9), 1)
         

--- a/cls/SourceControl/Git/WebUIDriver.cls
+++ b/cls/SourceControl/Git/WebUIDriver.cls
@@ -223,18 +223,19 @@ ClassMethod HandleRequest(pagePath As %String, InternalName As %String = "", Out
                 set %data = ##class(%Stream.TmpCharacter).%New()
                 set changeTerminators = (%data.LineTerminator '= $char(13,10))
                 set %data.LineTerminator = $char(13,10) // For the CSPGateway.
+                do outStream.Rewind()
                 while 'outStream.AtEnd {
                     do %data.WriteLine(outStream.ReadLine())
                 }
 
                 set nLines = 0
+                do errStream.Rewind()
                 while 'errStream.AtEnd {
                     do %data.WriteLine(errStream.ReadLine())
                     set:changeTerminators nLines = nLines + 1
                 }
                 
-                // Need to write out two lines or we get an infinite loop in JavaScript...
-                do %data.WriteLine()
+                // Need to write out an extra newline
                 do %data.WriteLine()
                 do %data.WriteLine("Git-Stderr-Length: " _ (errStream.Size + nLines))
                 do %data.Write("Git-Return-Code: " _ returnCode) // No ending newline expected
@@ -425,3 +426,4 @@ ClassMethod GetRemote() As %Library.DynamicObject
 }
 
 }
+


### PR DESCRIPTION
Fixes #592
This is a minor regression in unreleased code, so not bothering with a changelog entry. Also added consistent checking of %gitSCOutputFlag - we've been getting some duplicated logs in Pull because of this