### PR TITLE
Added pull event handler for full import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Production Decomposition mode allows controlling interoperability productions as individual files for each host (#469)
 - Added saving settings as system default for new namespaces (#535)
 - Added filtering through branch names in UI (#615)
+- FullLoad pull event handler allows deploying changes with a full import of the repository (#619)
 
 ## [2.7.1] - 2024-11-13
 

--- a/cls/SourceControl/Git/Modification.cls
+++ b/cls/SourceControl/Git/Modification.cls
@@ -2,7 +2,7 @@
 Class SourceControl.Git.Modification Extends %RegisteredObject
 {
 
-/// path of the file
+/// path of the file relative to the Git repository
 Property externalName As %String;
 
 /// Name in IRIS SourceControl.Git.Modification

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -21,9 +21,14 @@ Method OnPull() As %Status [ Abstract ]
 }
 
 /// <var>files</var> is an integer-subscripted array of <class>SourceControl.Git.Modification</class> objects.
-ClassMethod ForModifications(ByRef files) As %Status
+/// <var>pullEventClass</var>: if defined, override the configured pull event class
+ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
 {
-    set event = $classmethod(##class(SourceControl.Git.Utils).PullEventClass(),"%New")
+    set event = $classmethod(
+        $select(
+            $data(pullEventClass)#2: pullEventClass, 
+            1: ##class(SourceControl.Git.Utils).PullEventClass())
+        ,"%New")
     set event.LocalRoot = ##class(SourceControl.Git.Utils).TempFolder()
     merge event.ModifiedFiles = files
     quit event.OnPull()

--- a/cls/SourceControl/Git/PullEventHandler/FullLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/FullLoad.cls
@@ -1,0 +1,14 @@
+Class SourceControl.Git.PullEventHandler.FullLoad Extends SourceControl.Git.PullEventHandler
+{
+
+Parameter NAME = "Full Load";
+
+Parameter DESCRIPTION = "Performs an full load and compile of all items in the repository.";
+
+Method OnPull() As %Status
+{
+    return ##class(SourceControl.Git.Utils).ImportAll(1, 
+        ##class(SourceControl.Git.PullEventHandler.IncrementalLoad).%ClassName(1))
+}
+
+}

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1573,7 +1573,7 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
             set modification = ##class(SourceControl.Git.Modification).%New()
             set modification.changeType = "M"
             set modification.internalName = internalName
-            set modification.externalName = ..FullExternalName(internalName)
+            set modification.externalName = ..ExternalName(internalName)
             set files($increment(files)) = modification
         }
     }
@@ -1588,13 +1588,14 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
         set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(item)
         continue:context.Package'=refPackage
             
+        set externalName = ..ExternalName(item)
         set fullExternalName = ..FullExternalName(item)
         if '##class(%File).Exists(fullExternalName) {
             write !,fullExternalName," does not exist - deleting ",item
             set modification = ##class(SourceControl.Git.Modification).%New()
             set modification.changeType = "D"
             set modification.internalName = item
-            set modification.externalName = fullExternalName
+            set modification.externalName = externalName
             set files($increment(files)) = modification
         }
     }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1536,7 +1536,7 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
     quit $$$OK
 }
 
-ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
+ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As %Status
 {
     set refContext = ##class(SourceControl.Git.PackageManagerContext).%Get()
     set refPackage = refContext.Package
@@ -1600,7 +1600,7 @@ ClassMethod ImportRoutines(force As %Boolean = 0) As %Status
         }
     }
     
-    set sc = ##class(SourceControl.Git.PullEventHandler).ForModifications(.files)
+    set sc = ##class(SourceControl.Git.PullEventHandler).ForModifications(.files, .pullEventClass)
     if $$$ISERR(sc) {
         set ec = $$$ADDSC(ec,sc)
     }
@@ -1733,9 +1733,10 @@ ClassMethod ExportSystemDefaults() As %Status
 }
 
 /// if <var>force</var> = 1 then we import item even if timestamp in system is newer
-ClassMethod ImportAll(force As %Boolean = 0) As %Status
+/// if <var>pullEventClass</var> is defined, then override the configured pull event handler class.
+ClassMethod ImportAll(force As %Boolean = 0, pullEventClass As %String) As %Status
 {
-    quit ..ImportRoutines(force)
+    quit ..ImportRoutines(force, .pullEventClass)
 }
 
 ClassMethod ExportRoutines(force As %Boolean = 0) As %Status


### PR DESCRIPTION
Resolves #619 

FullLoad handler will call Import All with Force. Import All handles deletes by deleting any items that exist in the Embedded Git timestamp cache but do not exist in the Git repository. I think that is the level of smartness for deletes we want in this case: if an item was deployed or edited with Embedded Git, it will get deleted properly; if it exists on the server for some other reason, it will not get deleted.

Changes here got tangled up with #469, so I'm going to mark this as a draft until production decomposition is merged and then rebase it onto main.