### PR TITLE
fix: add save flags to menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FullLoad pull event handler allows deploying changes with a full import of the repository (#619)
 - Pull and Sync options no longer log a fatal error if remote branch does not exist (#562)
 
-## Fixed
+### Fixed
 - Fixed minor issues in Studio UI (#641)
+- Document save is forced before menu operations that can modify repository state
 
 ## [2.7.1] - 2024-11-13
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -13,25 +13,25 @@ XData Menu
 <MenuItem Name="Status" />
 <MenuItem Name="Settings" />
 <MenuItem Name="Init" />
-<MenuItem Name="GitWebUI" Save="100" />
+<MenuItem Name="GitWebUI" Save="101" />
 <MenuItem Separator="true"/>
 <MenuItem Name="AddToSC" Save="100" />
 <MenuItem Name="RemoveFromSC"/>
 <MenuItem Name="Revert" Save="100" />
 <MenuItem Name="Commit" Save="100" />
 <MenuItem Separator="true"/>
-<MenuItem Name="Sync" Save="100" />
+<MenuItem Name="Sync" Save="101" />
 <MenuItem Name="Push" />
 <MenuItem Name="PushForce" />
-<MenuItem Name="Fetch" Save="100" />
-<MenuItem Name="Pull" Save="100" />
+<MenuItem Name="Fetch" Save="101" />
+<MenuItem Name="Pull" Save="101" />
 <MenuItem Separator="true"/>
-<MenuItem Name="NewBranch" Save="100" />
-<MenuItem Name="SwitchBranch" Save="100" />
+<MenuItem Name="NewBranch" Save="101" />
+<MenuItem Name="SwitchBranch" Save="101" />
 <MenuItem Separator="true"/>
 <MenuItem Name="ExportSystemDefaults" />
-<MenuItem Name="Export" Save="100" />
-<MenuItem Name="ExportForce" Save="100" />
+<MenuItem Name="Export" Save="101" />
+<MenuItem Name="ExportForce" Save="101" />
 <MenuItem Name="Import" />
 <MenuItem Name="ImportForce" />
 </Menu>

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -13,33 +13,33 @@ XData Menu
 <MenuItem Name="Status" />
 <MenuItem Name="Settings" />
 <MenuItem Name="Init" />
-<MenuItem Name="GitWebUI" />
+<MenuItem Name="GitWebUI" Save="100" />
 <MenuItem Separator="true"/>
-<MenuItem Name="AddToSC" />
+<MenuItem Name="AddToSC" Save="100" />
 <MenuItem Name="RemoveFromSC"/>
-<MenuItem Name="Revert" />
-<MenuItem Name="Commit" />
+<MenuItem Name="Revert" Save="100" />
+<MenuItem Name="Commit" Save="100" />
 <MenuItem Separator="true"/>
-<MenuItem Name="Sync" />
+<MenuItem Name="Sync" Save="100" />
 <MenuItem Name="Push" />
 <MenuItem Name="PushForce" />
-<MenuItem Name="Fetch" />
-<MenuItem Name="Pull" />
+<MenuItem Name="Fetch" Save="100" />
+<MenuItem Name="Pull" Save="100" />
 <MenuItem Separator="true"/>
-<MenuItem Name="NewBranch" />
-<MenuItem Name="SwitchBranch" />
+<MenuItem Name="NewBranch" Save="100" />
+<MenuItem Name="SwitchBranch" Save="100" />
 <MenuItem Separator="true"/>
 <MenuItem Name="ExportSystemDefaults" />
-<MenuItem Name="Export" />
-<MenuItem Name="ExportForce" />
+<MenuItem Name="Export" Save="100" />
+<MenuItem Name="ExportForce" Save="100" />
 <MenuItem Name="Import" />
 <MenuItem Name="ImportForce" />
 </Menu>
 <Menu Name="%SourceContext" Type="1">
-<MenuItem Name="AddToSC" />
+<MenuItem Name="AddToSC" Save="100" />
 <MenuItem Name="RemoveFromSC"/>
-<MenuItem Name="Revert" />
-<MenuItem Name="Commit" />
+<MenuItem Name="Revert" Save="100" />
+<MenuItem Name="Commit" Save="100" />
 </Menu>
 </MenuBase>
 }


### PR DESCRIPTION
I got a question re: the Save flag behavior on menu items from Brett the other day, and realized we're totally missing these for Embedded Git. Surprised this hasn't come up before.

Use case: before I commit (or do something that could modify the filesystem representation of the current document!), I need to be forced to actually save my changes to the current document.