### PR TITLE
Fixes to instance-wide uncommitted queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed errors on production page when item settings need to be XML escaped (#667)
+- No longer display instance-wide uncommitted warning with decomposed production (#547)
 
 ## [2.8.0] - 2024-12-06
 

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -202,7 +202,7 @@ Query InstanceUncommitted() As %Query(ROWSPEC = "InternalName:%String,User:%Stri
 
 ClassMethod InstanceUncommittedExecute(ByRef qHandle As %Binary) As %Status
 {
-    set qHandle("q") = "SELECT InternalName, ChangedBy FROM SourceControl_Git.Change"
+    set initNS = $namespace
     &sql(DECLARE InstanceCursor CURSOR FOR SELECT InternalName, ChangedBy into :internalName, :changedBy from SourceControl_Git.Change)
     set namespaces = ##class(SourceControl.Git.Utils).GetGitEnabledNamespaces()
     set tPtr = 0
@@ -210,7 +210,7 @@ ClassMethod InstanceUncommittedExecute(ByRef qHandle As %Binary) As %Status
     new $namespace
     while $LISTNEXT(namespaces, tPtr, tValue) {
         set namespace = $ZCONVERT(tValue, "U")
-        if '(namespace [ "^") {
+        if '(namespace [ "^") && (namespace '= initNS) {
             set $NAMESPACE = namespace
                 
                 &sql(OPEN InstanceCursor)

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -217,9 +217,9 @@ ClassMethod InstanceUncommittedExecute(ByRef qHandle As %Binary) As %Status
                     throw:SQLCODE<0 ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE, %msg)
                 &sql(FETCH InstanceCursor)
                 while(SQLCODE = 0) {
-                    set qHandle("changes", $increment(qHandle("changes")), "InternalName") = internalName
-                    set qHandle("changes", qHandle("changes"), "User") = changedBy
-                    set qHandle("changes", qHandle("changes"), "Namespace") = namespace
+                    set ^||InstanceUncommitted("changes", $increment(^||InstanceUncommitted("changes")), "InternalName") = internalName
+                    set ^||InstanceUncommitted("changes", ^||InstanceUncommitted("changes"), "User") = changedBy
+                    set ^||InstanceUncommitted("changes", ^||InstanceUncommitted("changes"), "Namespace") = namespace
                     &sql(FETCH InstanceCursor)
                 }
                 &sql(CLOSE InstanceCursor)
@@ -232,10 +232,10 @@ ClassMethod InstanceUncommittedExecute(ByRef qHandle As %Binary) As %Status
 ClassMethod InstanceUncommittedFetch(ByRef qHandle As %Binary, ByRef Row As %List, ByRef AtEnd As %Integer = 0) As %Status [ PlaceAfter = InstanceUncommittedExecute ]
 {
     set i = qHandle("i")
-    if $data(qHandle("changes",i))=10 {
-        set Row = $listbuild(qHandle("changes", i, "InternalName"), qHandle("changes", i, "User"), qHandle("changes", i, "Namespace"))
+    if $data(^||InstanceUncommitted("changes",i))=10 {
+        set Row = $listbuild(^||InstanceUncommitted("changes", i, "InternalName"), ^||InstanceUncommitted("changes", i, "User"), ^||InstanceUncommitted("changes", i, "Namespace"))
     }
-    if i >= $get(qHandle("changes"),0) {
+    if i >= $get(^||InstanceUncommitted("changes"),0) {
         set AtEnd = 1
     } else {
         set qHandle("i") = $increment(qHandle("i"))

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -56,23 +56,23 @@ Method UserAction(Type As %Integer, Name As %String, InternalName As %String, Se
     }
 
     if (Type = 1) && (Name = 3) {
-        if settings.warnInstanceWideUncommitted {
-            // if item is being edited in a different namespace, opening it will display an alert. Editing in this namespace will remove the alert.
-            set filename = ##class(SourceControl.Git.Utils).FullExternalName(.InternalName)
-            do ##class(SourceControl.Git.Change).GetUncommitted(filename,.tAction)
-            do ..GetStatus(.InternalName, .isInSourceControl, .isEditable,.isCheckedOut,.userCheckedOut)
-            if '$data(tAction) {
-                set user = "", inNamespace = ""
-                if 'isEditable || ##class(SourceControl.Git.Utils).Locked() {
-                    set Target = "Warning: Attempting to edit read-only file"
-                    write !, Target
-                    set Action = 6
-                } elseif ##class(SourceControl.Git.Utils).InstanceWideUncommittedCheck(InternalName, .user, .inNamespace) {
-                    set Target = "Warning: Item " _ InternalName _ " is currently being modified by " _ user _ " in namespace " _ inNamespace _ "."
-                    write !, Target
-                    set Action = 6
-                } 
-            }
+        set filename = ##class(SourceControl.Git.Utils).FullExternalName(.InternalName)
+        do ##class(SourceControl.Git.Change).GetUncommitted(filename,.tAction)
+        do ..GetStatus(.InternalName, .isInSourceControl, .isEditable,.isCheckedOut,.userCheckedOut)
+        if '$data(tAction) {
+            set user = "", inNamespace = ""
+            if 'isEditable || ##class(SourceControl.Git.Utils).Locked() {
+                set Target = "Warning: Attempting to edit read-only file"
+                write !, Target
+                set Action = 6
+            } elseif settings.warnInstanceWideUncommitted 
+                    && ##class(SourceControl.Git.Utils).InstanceWideUncommittedCheck(InternalName, .user, .inNamespace) 
+                    && '(##class(SourceControl.Git.Utils).ItemIsProductionToDecompose(InternalName)) {
+                // if item is being edited in a different namespace, opening it will display an alert. Editing in this namespace will remove the alert.
+                set Target = "Warning: Item " _ InternalName _ " is currently being modified by " _ user _ " in namespace " _ inNamespace _ "."
+                write !, Target
+                set Action = 6
+            } 
         }
     }
 


### PR DESCRIPTION
A number of fixes related to the instance-wide uncommitted queue:
- Fix sluggish performance if another namespace has a large number of uncommitted changes
- The locked file warning if a file is edited on this namespace now displays even if the instance-wide uncommitted check is disabled
- A decomposed production class no longer displays the instance-wide uncommitted warning as it is never relevant.

Resolves #547 
Potentially related to #668