### PR TITLE
Import All now imports Embedded Git configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed not showing warnings on Studio (#660)
 - Fixed business processes and rules not being added to source control automatically (#676)
 - Embedded Git commits settings when cloning empty repo to avert any issues
+- Fixed Import All options not importing the Embedded Git configuration file
 
 ## [2.9.0] - 2025-01-09
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1491,6 +1491,12 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
 {
     #define DoNotLoad 1
     set res = $$$OK
+
+    // Config file may exist at the root of the Git repo.
+    set configFilePath = ##class(%File).NormalizeFilename(##class(SourceControl.Git.Settings.Document).#EXTERNALNAME, ..TempFolder())
+    if ##class(%File).Exists(##class(%File).NormalizeFilename(configFilePath)) {
+        set itemList(..NameToInternalName(configFilePath)) = ""
+    }
     
     set mappingFileType = $order($$$SourceMapping(""))
     while (mappingFileType '= "") {


### PR DESCRIPTION
The config file not being imported could cause issues, especially with turning on the production decomposition setting in new environments.