### PR TITLE
Improvements to deployment of production items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - LoadProductionsFromDirectory method to help custom deployment scripts load decomposed productions from the repository (#670)
 - Added ability to reset head / revert most recent commit (#586)
+- Changes deployed through Git are now logged in a new table SourceControl_Git.DeploymentLog
 
 ### Fixed
 - Fixed not showing warnings on Studio (#660)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Import All options not importing the Embedded Git configuration file
 - Improved performance of IDE editing and baselining of decomposed productions
 - Fixed Discard / Stash not working on deletes (#688)
+- Improved performance of deploying changes to decomposed production items (#690)
 
 ## [2.9.0] - 2025-01-09
 

--- a/cls/SourceControl/Git/DeploymentLog.cls
+++ b/cls/SourceControl/Git/DeploymentLog.cls
@@ -1,0 +1,44 @@
+Class SourceControl.Git.DeploymentLog Extends %Persistent [ Owner = {%Developer} ]
+{
+
+Property Token As %String [ InitialExpression = {$System.Util.CreateGUID()} ];
+
+Property StartTimestamp As %TimeStamp;
+
+Property EndTimestamp As %TimeStamp;
+
+Property HeadRevision As %String;
+
+Property Status As %Status;
+
+Storage Default
+{
+<Data name="DeploymentLogDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>Token</Value>
+</Value>
+<Value name="3">
+<Value>StartTimestamp</Value>
+</Value>
+<Value name="4">
+<Value>EndTimestamp</Value>
+</Value>
+<Value name="5">
+<Value>HeadRevision</Value>
+</Value>
+<Value name="6">
+<Value>Status</Value>
+</Value>
+</Data>
+<DataLocation>^SourceContro22B9.DeploymentLogD</DataLocation>
+<DefaultData>DeploymentLogDefaultData</DefaultData>
+<IdLocation>^SourceContro22B9.DeploymentLogD</IdLocation>
+<IndexLocation>^SourceContro22B9.DeploymentLogI</IndexLocation>
+<StreamLocation>^SourceContro22B9.DeploymentLogS</StreamLocation>
+<Type>%Storage.Persistent</Type>
+}
+
+}

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -24,6 +24,10 @@ Method OnPull() As %Status [ Abstract ]
 /// <var>pullEventClass</var>: if defined, override the configured pull event class
 ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
 {
+    set log = ##class(SourceControl.Git.DeploymentLog).%New()
+    set log.HeadRevision = ##class(SourceControl.Git.Utils).GetCurrentRevision()
+    set log.StartTimestamp = $zdatetime($ztimestamp,3)
+    do log.%Save()
     set event = $classmethod(
         $select(
             $data(pullEventClass)#2: pullEventClass, 
@@ -31,7 +35,11 @@ ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
         ,"%New")
     set event.LocalRoot = ##class(SourceControl.Git.Utils).TempFolder()
     merge event.ModifiedFiles = files
-    quit event.OnPull()
+    set st = event.OnPull()
+    set log.EndTimestamp = $zdatetime($ztimestamp,3)
+    set log.Status = st
+    do log.%Save()
+    quit st
 }
 
 /// <var>InternalName</var> may be a comma-delimited string or $ListBuild list

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -24,21 +24,28 @@ Method OnPull() As %Status [ Abstract ]
 /// <var>pullEventClass</var>: if defined, override the configured pull event class
 ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
 {
-    set log = ##class(SourceControl.Git.DeploymentLog).%New()
-    set log.HeadRevision = ##class(SourceControl.Git.Utils).GetCurrentRevision()
-    set log.StartTimestamp = $zdatetime($ztimestamp,3)
-    do log.%Save()
-    set event = $classmethod(
-        $select(
-            $data(pullEventClass)#2: pullEventClass, 
-            1: ##class(SourceControl.Git.Utils).PullEventClass())
-        ,"%New")
-    set event.LocalRoot = ##class(SourceControl.Git.Utils).TempFolder()
-    merge event.ModifiedFiles = files
-    set st = event.OnPull()
-    set log.EndTimestamp = $zdatetime($ztimestamp,3)
-    set log.Status = st
-    do log.%Save()
+    set st = $$$OK
+    try {
+        set log = ##class(SourceControl.Git.DeploymentLog).%New()
+        set log.HeadRevision = ##class(SourceControl.Git.Utils).GetCurrentRevision()
+        set log.StartTimestamp = $zdatetime($ztimestamp,3)
+        set st = log.%Save()
+        quit:$$$ISERR(st)
+        set event = $classmethod(
+            $select(
+                $data(pullEventClass)#2: pullEventClass, 
+                1: ##class(SourceControl.Git.Utils).PullEventClass())
+            ,"%New")
+        set event.LocalRoot = ##class(SourceControl.Git.Utils).TempFolder()
+        merge event.ModifiedFiles = files
+        set st = event.OnPull()
+        set log.EndTimestamp = $zdatetime($ztimestamp,3)
+        set log.Status = st
+        set st = log.%Save()
+        quit:$$$ISERR(st)
+    } catch err {
+        set st = err.AsStatus()
+    }
     quit st
 }
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -754,6 +754,7 @@ ClassMethod Exists(ByRef pFilename) As %Boolean
 	Return 0
 }
 
+/// Adds this item to the list of items that are tracked by source control
 ClassMethod AddToServerSideSourceControl(InternalName As %String) As %Status
 {
     #dim i as %Integer
@@ -764,10 +765,6 @@ ClassMethod AddToServerSideSourceControl(InternalName As %String) As %Status
             continue
         }
         set @..#Storage@("items", item) = ""
-        #dim sc as %Status =  ..ImportItem(item, 1)
-        if 'sc {
-            set ec = $$$ADDSC(ec, sc)
-        }
     }
     quit ec
 }


### PR DESCRIPTION
Resolves #690 

Prior to this change we were calling ImportItem() twice for every item changed by a Git operation. Once through AddToServerSideSourceControl, and once through the pull event handler. This made every Git operation changing productions twice as long as it needed to be. This was only an issue for production items because other items have a timestamp from %RoutineMgr that lets us skip the import if the item is up to date in IRIS.

Also adds a separate table that logs deployments into IRIS through the pull event handler.