### PR TITLE
Fix errors with decomposed production with invalid cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Import All options not importing the Embedded Git configuration file
 - Improved performance of IDE editing and baselining of decomposed productions
 - Fixed Discard / Stash not working on deletes (#688)
+- Fixed errors saving decomposed productions when invalid items in item cache (#701)
+- Removed unnecessary Add and Remove menu items from decomposed productions (#701)
 
 ## [2.9.0] - 2025-01-09
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -263,7 +263,9 @@ Method OnSourceMenuContextItem(itemName As %String, menuItemName As %String, ByR
         } else {
             set Enabled = $case(menuItemName, "AddToSC":1,:-1)
         }
-
+    }
+    if ##class(SourceControl.Git.Utils).ItemIsProductionToDecompose(itemName) && ((menuItemName = "AddToSC") || (menuItemName = "RemoveFromSC")) {
+        set Enabled = -1
     }
     if (menuItemName '= "") {
 	    set DisplayName = ..LocalizeName(menuItemName)
@@ -365,8 +367,7 @@ Method OnAfterSave(InternalName As %String, Object As %RegisteredObject = {$$$NU
                 if $data(productionItems) {
                     do ##class(SourceControl.Git.Change).RefreshUncommitted(,,,1)
                 }
-            }
-            if ..IsInSourceControl(InternalName) {
+            } elseif ..IsInSourceControl(InternalName) {
                 if fromWebApp {
                     if fullExternalName = ##class(SourceControl.Git.Utils).FullExternalName(InternalName) {
                         // Reimport item into database

--- a/test/UnitTest/SourceControl/Git/ProductionDecomposition.cls
+++ b/test/UnitTest/SourceControl/Git/ProductionDecomposition.cls
@@ -156,8 +156,8 @@ XData ProductionDefinition3
 
 Method OnBeforeAllTests() As %Status
 {
-	merge ..SourceControlGlobal = ^SYS("SourceControl")
-    return $$$OK
+  merge ..SourceControlGlobal = ^SYS("SourceControl")
+  return ##class(Ens.Director).StopProduction(,1)
 }
 
 Method OnBeforeOneTest() As %Status


### PR DESCRIPTION
Closes #701 
- Fix an error when there is a leftover entry in the Git items cache for the undecomposed production class
- Removes Add to / Remove From Source Control options from menu for decomposed production since they do nothing