### PR TITLE
Production decomposition with new interoperability editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Pull event handler that does an IPM uninstall and load to handle deletes (#631)
+- Partial support for production decomposition with the new interoperability editors
 
 ## [2.10.0] - 2025-02-10
 

--- a/cls/SourceControl/Git/Production.cls
+++ b/cls/SourceControl/Git/Production.cls
@@ -335,7 +335,10 @@ ClassMethod GetModifiedItemsAfterSave(internalName, Output modifiedItems)
 ClassMethod IsEnsPortal() As %Boolean
 {
 	Return $Data(%request) && '($IsObject(%request) && 
-        ((%request.UserAgent [ "Code") || (%request.UserAgent [ "node-fetch")))
+        (  
+            (%request.UserAgent [ "Code")   // VS Code
+            || (%request.UserAgent [ "node-fetch")  // VS Code
+            || (%request.Application [ "/api/interop-editors")))  // New interoperability editor
 }
 
 /// Perform check if Production Decomposition logic should be used for given item


### PR DESCRIPTION
Small fix that makes it safe to edit productions through the new interoperability UI with production decomposition. Edits from the new UI will be treated like edits from the IDE, which means:
- it is read-only unless the "Decomposed Productions Allow IDE" setting is enabled
- you are locked from editing any item in the production if a different user has checked out any item on the production.