### PR TITLE
Issue 693 Add interoperability files to Baseline Export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - Unreleased
+
+### Added
+- Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
+
 ## [2.11.0] - 2025-04-23
 
 ### Added
@@ -12,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partial support for production decomposition with the new interoperability editors
 - Added Lock Branch setting to prevent switching branches for a protected namespace (#709)
 - Tooltips on branch operations in Git UI (#725)
-- Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
 
 ### Fixed
 - Changing system mode (environment name) in settings persists after instance restart (#655)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partial support for production decomposition with the new interoperability editors
 - Added Lock Branch setting to prevent switching branches for a protected namespace (#709)
 - Tooltips on branch operations in Git UI (#725)
+- Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
 
 ### Fixed
 - Changing system mode (environment name) in setting spersists after instance restart (#655)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2981,7 +2981,7 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
     try {
         write !, "Exporting items..."
         set rs = ##class(%Library.RoutineMgr).StudioOpenDialogFunc(
-            "*.mac,*.int,*.inc,*.cls,*.csp" 
+            "*.mac,*.int,*.inc,*.cls,*.csp,*.HL7,*.LUT,*.AST,*.X12"
             , , ,0  // SystemFiles 
             ,1      // Flat
             ,0      // NotStudio
@@ -2992,6 +2992,7 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
         while rs.%Next(.sc) {
             $$$ThrowOnError(sc)
             set internalName = rs.Name
+            continue:..IsSchemaStandard(internalName)
             // exclude items in a non-default IPM package
             set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(internalName)
             continue:($isobject(context.Package) && 'context.IsInDefaultPackage)
@@ -3181,5 +3182,19 @@ ClassMethod GitUnstage(Output output As %Library.DynamicObject) As %Status
     return $$$OK
 }
 
+ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
+{
+	Set parts = $Length(pName,".")
+	Set category = $Piece(pName,".",1,parts-1)
+	Set ext = $Piece(pName,".",parts)
+	If (pName = "") {
+		Quit 0
+	}
+	Quit +$Case(ext,
+		"AST":$Get(^EnsEDI.ASTM.Description(category,"std")),
+		"HL7":$Get(^EnsHL7.Description(category,"std")),
+		"X12":$Get(^EnsEDI.X12.Description(category,"std")),
+		:0)
 }
 
+}

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="git-source-control.ZPM">
     <Module>
       <Name>git-source-control</Name>
-      <Version>2.11.0</Version>
+      <Version>2.12.0</Version>
       <Description>Server-side source control extension for use of Git on InterSystems platforms</Description>
       <Keywords>git source control studio vscode</Keywords>
       <Packaging>module</Packaging>


### PR DESCRIPTION
BaselineExport method now includes custom HL7, AST, X12 schemas, and LUT. excludes standard schemas.