### PR TITLE
Improve display of preview on pull page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
 
+### Fixed
+- Pull page output now displays better when pull preview shows a lot of changes (#740)
+
 ## [2.11.0] - 2025-04-23
 
 ### Added

--- a/csp/pull.csp
+++ b/csp/pull.csp
@@ -25,7 +25,7 @@
 	</server>
 </select>
 </pre>
-<pre id="preview" style="white-space: pre-wrap;">
+<pre id="preview" style="white-space: pre-wrap; max-height: 30%">
 </pre>
 <button id="execute" onclick="execute()" disabled="true">Pull and Load Changes</button>
 <pre id="pull" style="white-space: pre-wrap;">


### PR DESCRIPTION
Resolves #740 
If there are a lot of changes in the pull preview, it can take up the full page. The scrolling behavior with pre tags is not super intuitive. Adding a max height to the preview makes it easier to see the results.