### PR TITLE
Git links in favorites now actually work

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2685,8 +2685,8 @@ ClassMethod ConfigureWeb()
     new $Namespace
     set $Namespace = "%SYS"
     write !,"Adding favorites for all users:"
-    set sql = "insert or update into %SYS_Portal.Users (Username, Page, Data) "_
-        "select ID,?,$LISTBUILD(?) from Security.Users"
+    set sql = "insert or update %NOCHECK into %SYS_Portal.Users (Username, Page, Data) "_
+        "select ID,?,? from Security.Users"
     set caption = "Git: "_installNamespace
     set link = "/isc/studio/usertemplates/gitsourcecontrol/webuidriver.csp/"_installNamespace_"/"
     write !,"Adding Git favorite... "
@@ -3182,3 +3182,4 @@ ClassMethod GitUnstage(Output output As %Library.DynamicObject) As %Status
 }
 
 }
+


### PR DESCRIPTION
Related to #734 
The fix from #737 made the favorites links appear, but the hyperlink itself did not work because the SMP doesn't expect the URL to be in a $list format. See upstream reference DP-440691.

This fix is tested in both IRIS 2025.1.0 and 2023.1.3.