### PR TITLE
Mappings expand <namespace> parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
-- Mapping configuration expands \<namespace\> parameter to support namespace-specific mappings (#710)
+- Mapping configuration expands \<namespace\> and \<token\> parameters to better support multi-namespace solutions (#710)
 - Settings page includes a test of the connection to the remote (#746)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
+- Mapping configuration expands \<namespace\> parameter to support namespace-specific mappings (#710)
 - Settings page includes a test of the connection to the remote (#746)
 
 ### Fixed

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -65,6 +65,9 @@ Property environmentName As %String(MAXLEN = "") [ InitialExpression = {##class(
 /// Whether the branch should or should not be locked down from changing namespaces
 Property lockBranch As %Boolean [ InitialExpression = {##class(SourceControl.Git.Utils).LockBranch()} ];
 
+/// (Optional) A namespace-specific string that may be included in mapping configurations as <token> to support multi-namespace repositories
+Property mappingsToken As %String(MAXLEN = "") [ InitialExpression = {##class(SourceControl.Git.Utils).MappingsToken()} ];
+
 Property Mappings [ MultiDimensional ];
 
 Property favoriteNamespaces As %DynamicArray;
@@ -157,6 +160,7 @@ Method %Save() As %Status
     set @storage@("settings", "basicMode") = ..systemBasicMode
     set @storage@("settings", "environmentName") = ..environmentName
     set @storage@("settings", "lockBranch") = ..lockBranch
+    set @storage@("settings", "mappingsToken") = ..mappingsToken
     if ..basicMode = "system" {
         kill @storage@("settings", "user", $username, "basicMode")
     } else {
@@ -519,3 +523,4 @@ Method SaveDefaults() As %Boolean
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2425,10 +2425,12 @@ ClassMethod Name(InternalName As %String, ByRef MappingExists As %Boolean) As %S
 
 ClassMethod ExpandMappingParameters(MapDirectory, Settings As SourceControl.Git.Settings = {##class(SourceControl.Git.Settings).%New()})
 {
-    return $replace(MapDirectory,"<env>", $zconvert($select(
+    set expandedDir = $replace(MapDirectory,"<env>", $zconvert($select(
             Settings.environmentName = "": "DEVELOPMENT", 
             1: Settings.environmentName)
         ,"l"))
+    set expandedDir = $replace(expandedDir,"<namespace>", $zconvert($namespace,"l"))
+    return expandedDir
 }
 
 /// Implementation copied from %Library.RoutineMgr, but with results cached in a PPG.

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -190,6 +190,11 @@ ClassMethod LockBranch() As %Boolean
     quit $get(@..#Storage@("settings","lockBranch"),0)
 }
 
+ClassMethod MappingsToken() As %String
+{
+    quit $get(@..#Storage@("settings","mappingsToken"),"")
+}
+
 ClassMethod IsLIVE() As %Boolean
 {
     quit ..EnvironmentName()="LIVE"
@@ -2430,6 +2435,7 @@ ClassMethod ExpandMappingParameters(MapDirectory, Settings As SourceControl.Git.
             1: Settings.environmentName)
         ,"l"))
     set expandedDir = $replace(expandedDir,"<namespace>", $zconvert($namespace,"l"))
+    set expandedDir = $replace(expandedDir,"<token>", Settings.mappingsToken)
     return expandedDir
 }
 
@@ -3219,3 +3225,4 @@ ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
 }
 
 }
+

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -109,7 +109,7 @@ body {
             set $Property(settings,param) = $Get(%request.Data(param,1))
         }
         if ('settings.settingsUIReadOnly) {
-            for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName" {
+            for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName","mappingsToken" {
                 set $Property(settings,param) = $Get(%request.Data(param,1))
             }
 
@@ -274,7 +274,7 @@ body {
         </div>
 
         <div class="form-group row mb-3">
-            <label for="namespaceTemp" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Absolute path to you project">Git Repo Root Directory<br/></label>
+            <label for="namespaceTemp" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Absolute path to your project">Git Repo Root Directory<br/></label>
             <server>
                 set dir = ##class(%File).NormalizeDirectory(settings.namespaceTemp)
                 if (settings.namespaceTemp '= "") && ##class(%File).DirectoryExists(dir_".git") {
@@ -504,6 +504,12 @@ body {
                         id="lockBranch" #($select(settings.lockBranch:"checked",1:""))# value="1">
                     <label class="custom-control-label" for="lockBranch"></label>
                 </div>
+            </div>
+        </div>
+        <div class="form-group row mb-3">
+            <label for="mappingsToken" class="offset-sm-1 col-sm-3 col-form-label" data-toggle="tooltip" data-placement="top" title="(Optional) A namespace-specific string that may be included in mapping configurations as <token> to support multi-namespace repositories">Mappings Token</label>
+            <div class="col-sm-7">
+                <input type="text" class="form-control" id="mappingsToken" name="mappingsToken" value='#(..EscapeHTML(settings.mappingsToken))#'>
             </div>
         </div>
         

--- a/test/UnitTest/SourceControl/Git/NameTest.cls
+++ b/test/UnitTest/SourceControl/Git/NameTest.cls
@@ -70,12 +70,15 @@ Method TestParamExpansion()
         set $$$SourceMapping("ESD","*") = "config/<env>/"
         set $$$SourceMapping("ESD","*","NoFolders") = 1
         set $$$SourceMapping("CLS","*") = "<namespace>/cls/"
+        set $$$SourceMapping("INC","*") = "<token>/inc/"
         set settings = ##class(SourceControl.Git.Settings).%New()
         set oldEnvName = settings.environmentName
         set settings.environmentName = "TEST"
+        set settings.mappingsToken = "mdi"
         $$$ThrowOnError(settings.%Save())
         do $$$AssertEquals(##class(SourceControl.Git.Utils).Name("Ens.Config.DefaultSettings.esd"),"config/test/Ens.Config.DefaultSettings.esd")
         do $$$AssertEquals(##class(SourceControl.Git.Utils).Name("test.class.cls"),$zconvert($namespace,"l")_"/cls/test/class.cls")
+        do $$$AssertEquals(##class(SourceControl.Git.Utils).Name("test.routine.inc"),"mdi/inc/test/routine.inc")
     } catch err {
         do $$$AssertStatusOK(err.AsStatus())
     }

--- a/test/UnitTest/SourceControl/Git/NameTest.cls
+++ b/test/UnitTest/SourceControl/Git/NameTest.cls
@@ -64,16 +64,18 @@ Method TestMixedFoldering()
     do $$$AssertEquals(##class(Utils).Name("TestPackage.Hello.World.mac"),"rtn/TestPackage/Hello/World.mac")
 }
 
-Method TestEnvExpansion()
+Method TestParamExpansion()
 {
     try {
         set $$$SourceMapping("ESD","*") = "config/<env>/"
         set $$$SourceMapping("ESD","*","NoFolders") = 1
+        set $$$SourceMapping("CLS","*") = "<namespace>/cls/"
         set settings = ##class(SourceControl.Git.Settings).%New()
         set oldEnvName = settings.environmentName
         set settings.environmentName = "TEST"
         $$$ThrowOnError(settings.%Save())
         do $$$AssertEquals(##class(SourceControl.Git.Utils).Name("Ens.Config.DefaultSettings.esd"),"config/test/Ens.Config.DefaultSettings.esd")
+        do $$$AssertEquals(##class(SourceControl.Git.Utils).Name("test.class.cls"),$zconvert($namespace,"l")_"/cls/test/class.cls")
     } catch err {
         do $$$AssertStatusOK(err.AsStatus())
     }


### PR DESCRIPTION
Mapping configurations may now include the \<namespace\> token. The token will be expanded to the name of the current namespace. This is the first step towards supporting an instance-wide monorepository in which custom code for each namespace is mapped to a different subdirectory.
Resolves #710 and #756 