### PR TITLE
Improve remote management on settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expanded Baseline Export to include custom HL7, X12, ASTM schemas and Lookup Tables (#693)
+- Settings page includes a test of the connection to the remote (#746)
 
 ### Fixed
 - Deletes are now properly owned by the user who did the delete (#729)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Deletes are now properly owned by the user who did the delete (#729)
 - Pull page output now displays better when pull preview shows a lot of changes (#740)
+- Changing remotes in the git project settings pages now works if remote is not already defined (#746)
 
 ## [2.11.0] - 2025-04-23
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -3019,15 +3019,23 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
     return sc
 }
 
-/// Returns the url for the remote repository (censoring the username)
-ClassMethod GetConfiguredRemote() As %String
+/// Returns the url for the "origin" remote repository
+ClassMethod GetConfiguredRemote(Output remoteExists As %Boolean = 0) As %String
 {
-    d ..RunGitCommand("remote",.err,.out,"-v")
-    set line = out.ReadLine()
-    set url = $piece($piece(line,$char(9),2)," ",1)
+    set exitCode = ..RunGitCommand("remote",.err,.out,"get-url","origin")
+    if (exitCode = 0) {
+        set remoteExists = 1
+        set url = out.ReadLine()
+    } elseif (exitCode = 2) {
+        set remoteExists = 0
+        set url = ""
+    } else {
+        $$$ThrowStatus($$$ERROR($$$GeneralError,"git reported failure"))
+    }
     return url
 }
 
+/// Returns the url for the "origin" remote repository, redacting the username
 ClassMethod GetRedactedRemote() As %String
 {
     set url = ..GetConfiguredRemote()
@@ -3038,7 +3046,15 @@ ClassMethod GetRedactedRemote() As %String
 
 ClassMethod SetConfiguredRemote(url) As %String
 {
-    do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("remote",,.errStream,.outStream,"set-url","origin",url)
+    do ..GetConfiguredRemote(.remoteExists)
+    set returnCode = $select(
+        remoteExists&&(url=""): ##class(SourceControl.Git.Utils).RunGitCommandWithInput("remote",,.errStream,.outStream,"remove","origin"),
+        remoteExists&&(url'=""): ##class(SourceControl.Git.Utils).RunGitCommandWithInput("remote",,.errStream,.outStream,"set-url","origin",url),
+        'remoteExists&&(url'=""): ##class(SourceControl.Git.Utils).RunGitCommandWithInput("remote",,.errStream,.outStream,"add","origin",url),
+        1: 0)
+    if (returnCode '= 0) {
+        $$$ThrowStatus($$$ERROR($$$GeneralError,"git reported failure"))
+    }
     set output = outStream.ReadLine(outStream.Size)
     quit output
 }
@@ -3198,4 +3214,3 @@ ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
 }
 
 }
-

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -11,6 +11,7 @@
 <style type='text/css'>
 .error {
     color: red;
+    padding: 20px;
 }
 
 body {
@@ -101,97 +102,102 @@ body {
  set homeURL = ##class(SourceControl.Git.WebUIDriver).GetHomeURL()
 
  set settings = ##class(SourceControl.Git.Settings).%New()
- set remote = ##class(SourceControl.Git.Utils).GetRedactedRemote()
- /// After Save
- if (%request.Method="POST") && $Data(%request.Data("gitsettings",1)) {
-    for param="gitUserName","gitUserEmail" {
-        set $Property(settings,param) = $Get(%request.Data(param,1))
-    }
-    if ('settings.settingsUIReadOnly) {
-        for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName" {
+ try {
+    /// After Save
+    if (%request.Method="POST") && $Data(%request.Data("gitsettings",1)) {
+        for param="gitUserName","gitUserEmail" {
             set $Property(settings,param) = $Get(%request.Data(param,1))
         }
+        if ('settings.settingsUIReadOnly) {
+            for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName" {
+                set $Property(settings,param) = $Get(%request.Data(param,1))
+            }
 
-        if ($Get(%request.Data("mappedItemsReadOnly", 1)) = 1) {
-            set settings.mappedItemsReadOnly = 1
-        } else {
-            set settings.mappedItemsReadOnly = 0
-        }
+            if ($Get(%request.Data("mappedItemsReadOnly", 1)) = 1) {
+                set settings.mappedItemsReadOnly = 1
+            } else {
+                set settings.mappedItemsReadOnly = 0
+            }
 
-        set newRemote = $Get(%request.Data("remoteRepo",1))
-        // If entry was modified, set new remote repo
-        if (newRemote '= ##class(SourceControl.Git.Utils).GetRedactedRemote()) {
-            do ##class(SourceControl.Git.Utils).SetConfiguredRemote(newRemote)
-        }
+            set newRemote = $Get(%request.Data("remoteRepo",1))
+            // If entry was modified, set new remote repo
+            if (newRemote '= ##class(SourceControl.Git.Utils).GetRedactedRemote()) {
+                do ##class(SourceControl.Git.Utils).SetConfiguredRemote(newRemote)
+            }
 
-        set settings.compileOnImport = ($Get(%request.Data("compileOnImport", 1)) = 1)
-        set settings.decomposeProductions = ($Get(%request.Data("decomposeProductions", 1)) = 1)
-        set settings.decomposeProdAllowIDE = ($Get(%request.Data("decomposeProdAllowIDE", 1)) = 1)
-        set settings.lockBranch = ($Get(%request.Data("lockBranch", 1)) = 1)
+            set settings.compileOnImport = ($Get(%request.Data("compileOnImport", 1)) = 1)
+            set settings.decomposeProductions = ($Get(%request.Data("decomposeProductions", 1)) = 1)
+            set settings.decomposeProdAllowIDE = ($Get(%request.Data("decomposeProdAllowIDE", 1)) = 1)
+            set settings.lockBranch = ($Get(%request.Data("lockBranch", 1)) = 1)
 
-        if ($Get(%request.Data("basicMode", 1)) = 1) {
-            set settings.basicMode = 1
-        } elseif ($Get(%request.Data("basicMode", 1)) = "system"){
-            set settings.basicMode = "system"
-        } else {
-            set settings.basicMode = 0
-        }
+            if ($Get(%request.Data("basicMode", 1)) = 1) {
+                set settings.basicMode = 1
+            } elseif ($Get(%request.Data("basicMode", 1)) = "system"){
+                set settings.basicMode = "system"
+            } else {
+                set settings.basicMode = 0
+            }
 
-        if ($Get(%request.Data("systemBasicMode", 1)) = 1) {
-            set settings.systemBasicMode = 1
-        } else {
-            set settings.systemBasicMode = 0
-        }
-        set i = 1
-        set param = "NoFolders"
-        kill settings.Mappings
-        
-        while ( $Data(%request.Data("MappingsExt",i)) ){
-        if ($get(%request.Data("MappingsExt",i)) '= "") {
-                if ($Get(%request.Data(param,i)) = "NoFolders"){
-                    set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i)), $Get(%request.Data(param,i))) = 1
-                }
-                set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i))) = $Get(%request.Data("MappingsPath",i))
-        }
+            if ($Get(%request.Data("systemBasicMode", 1)) = 1) {
+                set settings.systemBasicMode = 1
+            } else {
+                set settings.systemBasicMode = 0
+            }
+            set i = 1
+            set param = "NoFolders"
+            kill settings.Mappings
+            
+            while ( $Data(%request.Data("MappingsExt",i)) ){
+            if ($get(%request.Data("MappingsExt",i)) '= "") {
+                    if ($Get(%request.Data(param,i)) = "NoFolders"){
+                        set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i)), $Get(%request.Data(param,i))) = 1
+                    }
+                    set settings.Mappings($Get(%request.Data("MappingsExt",i)), $Get(%request.Data("MappingsCov",i))) = $Get(%request.Data("MappingsPath",i))
+            }
+                set i = i+1
+            }
+
+            set i = 1
+            set contexts = []
+
+            while ( $Data(%request.Data("favNamespace",i)) ){
+            if ($Get(%request.Data("favNamespace",i)) '= "") {
+                do contexts.%Push($Get(%request.Data("favNamespace",i)))
+            }
             set i = i+1
-        }
+            }
 
-        set i = 1
-        set contexts = []
+            set settings.favoriteNamespaces = contexts
 
-        while ( $Data(%request.Data("favNamespace",i)) ){
-        if ($Get(%request.Data("favNamespace",i)) '= "") {
-            do contexts.%Push($Get(%request.Data("favNamespace",i)))
+            if ($get(%request.Data("proxySubmitButton",1)) = "saveDefaults") {
+                do settings.SaveDefaults()
+            }
         }
-        set i = i+1
+        set err = ""
+        try {
+            set buffer = ##class(SourceControl.Git.Util.Buffer).%New()
+            do buffer.BeginCaptureOutput()
+            $$$ThrowOnError(settings.SaveWithSourceControl())
+            do buffer.EndCaptureOutput(.out)
+            if (out '= "") {
+                &html<<div class="alert alert-primary">
+                        <div>#(..EscapeHTML(out))#</div>
+                    </div>>
+            }
+        } catch err {
+            kill buffer
+            throw err
         }
-
-        set settings.favoriteNamespaces = contexts
-
-        if ($get(%request.Data("proxySubmitButton",1)) = "saveDefaults") {
-            do settings.SaveDefaults()
-        }
+        set successfullySavedSettings = 1
     }
-    set err = ""
-    try {
-        set buffer = ##class(SourceControl.Git.Util.Buffer).%New()
-        do buffer.BeginCaptureOutput()
-        $$$ThrowOnError(settings.SaveWithSourceControl())
-        do buffer.EndCaptureOutput(.out)
-        if (out '= "") {
-            &html<<div class="alert alert-primary">
-                    <div>#(..EscapeHTML(out))#</div>
-                </div>>
-        }
-    } catch err {
-        kill buffer
-        do err.Log()
-        &html<<div class="alert alert-danger">An error occurred and has been logged to the application error log.</div>>
-    }
+    set remote = ##class(SourceControl.Git.Utils).GetRedactedRemote()
+} catch err {
+    do err.Log()
+    &html<<div class="error alert-danger">An error occurred and has been logged to the application error log.</div>>
 }
 </server>
 <div class = 'container'>
-    <csp:if condition='$D(%request.Data("gitsettings",1)) && (##class(SourceControl.Git.Utils).NeedSettings() = 0)'>
+    <csp:if condition='$get(successfullySavedSettings) && (##class(SourceControl.Git.Utils).NeedSettings() = 0)'>
         <div class = "alert">
         <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>  
         <strong>Success!</strong> Your changes have been saved.
@@ -416,9 +422,9 @@ body {
         </div>
 
         <div class="form-group row mb-3">
-            <label for="remoteRepo" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Url to Remote repository"><b>Remote Repository</b></label>
+            <label for="remoteRepo" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Url to Remote repository (origin)"><b>Remote Repository</b></label>
             <div class="col-sm-7">
-                <input type="text" class="form-control" id="remoteRepo" name="remoteRepo" value='#(..EscapeHTML(remote))#' placeholder="ex. git@github.com:User/UserRepo.git"/>
+                <input type="text" class="form-control" id="remoteRepo" name="remoteRepo" value='#(..EscapeHTML($get(remote)))#' placeholder="ex. git@github.com:User/UserRepo.git"/>
                 <div class = "neutral-feedback">
                     (Username is redacted)
                 </div>

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -191,6 +191,9 @@ body {
         set successfullySavedSettings = 1
     }
     set remote = ##class(SourceControl.Git.Utils).GetRedactedRemote()
+    if (remote'="") && (##class(SourceControl.Git.Utils).RunGitCommandWithInput("ls-remote",,.errStream,,"origin")'=0) {
+        set remoteConnectionError = errStream.Read()
+    }
 } catch err {
     do err.Log()
     &html<<div class="error alert-danger">An error occurred and has been logged to the application error log.</div>>
@@ -324,7 +327,7 @@ body {
                     set placeholder = $Select($system.Version.GetOS()="Windows":"(e.g. C:\Users\ExampleUser\.ssh\id_rsa)",
                         1:"(e.g., /home/user/.ssh/id_rsa)")
                 </server>
-                <input type="text" class="#(class)#" id="privateKeyFile" name="privateKeyFile" value='#(..EscapeHTML(settings.privateKeyFile))#' placeholder=#(placeholder)#/>
+                <input type="text" class="#(class)#" id="privateKeyFile" name="privateKeyFile" value='#(..EscapeHTML(settings.privateKeyFile))#' placeholder="#(..EscapeHTML(placeholder))#"/>
                 <div class = "#(divClass)#">
                     #(feedbackText)#
                     <pre id="sshOutput"></pre>
@@ -424,9 +427,15 @@ body {
         <div class="form-group row mb-3">
             <label for="remoteRepo" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Url to Remote repository (origin)"><b>Remote Repository</b></label>
             <div class="col-sm-7">
-                <input type="text" class="form-control" id="remoteRepo" name="remoteRepo" value='#(..EscapeHTML($get(remote)))#' placeholder="ex. git@github.com:User/UserRepo.git"/>
+                <input type="text" class='form-control #($select($get(remote)="":"",$get(remoteConnectionError)="":"is-valid",1:"is-invalid"))#' id="remoteRepo" name="remoteRepo" value='#(..EscapeHTML($get(remote)))#' placeholder="e.g. git@github.com:User/UserRepo.git"/>
                 <div class = "neutral-feedback">
                     (Username is redacted)
+                </div>
+                <div class="invalid-feedback">
+                    Unable to contact remote: #(..EscapeHTML($get(remoteConnectionError)))#
+                </div>
+                <div class="valid-feedback">
+                    Connection successful
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #746

Adding, removing, and updating remote now all work on the settings page.
Since settings page only allows changing a single remote, this is now constrained to be the "origin" remote. Previously behavior was undefined if there were multiple remotes.
If remote is defined, we now test connection and display a warning message if it fails.