### PR TITLE
Fix settings page remote input if git repo not initialized

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -3020,17 +3020,18 @@ ClassMethod BaselineExport(pCommitMessage = "", pPushToRemote = "") As %Status
 }
 
 /// Returns the url for the "origin" remote repository
-ClassMethod GetConfiguredRemote(Output remoteExists As %Boolean = 0) As %String
+ClassMethod GetConfiguredRemote(Output remoteExists As %Boolean = 0, Output sc As %Status = {$$$OK}) As %String
 {
     set exitCode = ..RunGitCommand("remote",.err,.out,"get-url","origin")
     if (exitCode = 0) {
         set remoteExists = 1
         set url = out.ReadLine()
-    } elseif (exitCode = 2) {
+    } else {
         set remoteExists = 0
         set url = ""
-    } else {
-        $$$ThrowStatus($$$ERROR($$$GeneralError,"git reported failure"))
+        if '$listfind($listbuild(2,3),exitCode) {
+            set sc = $$$ERROR($$$GeneralError,"git reported failure")
+        }
     }
     return url
 }

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -119,11 +119,6 @@ body {
                 set settings.mappedItemsReadOnly = 0
             }
 
-            set newRemote = $Get(%request.Data("remoteRepo",1))
-            // If entry was modified, set new remote repo
-            if (newRemote '= ##class(SourceControl.Git.Utils).GetRedactedRemote()) {
-                do ##class(SourceControl.Git.Utils).SetConfiguredRemote(newRemote)
-            }
 
             set settings.compileOnImport = ($Get(%request.Data("compileOnImport", 1)) = 1)
             set settings.decomposeProductions = ($Get(%request.Data("decomposeProductions", 1)) = 1)
@@ -187,6 +182,14 @@ body {
         } catch err {
             kill buffer
             throw err
+        }
+        set newRemote = $Get(%request.Data("remoteRepo",1))
+        // If entry was modified and git repo is initialized, set new remote repo
+        set dir = ##class(%File).NormalizeDirectory(settings.namespaceTemp)
+        if (settings.namespaceTemp '= "") && ##class(%File).DirectoryExists(dir_".git") {
+            if (newRemote '= ##class(SourceControl.Git.Utils).GetRedactedRemote()) {
+                do ##class(SourceControl.Git.Utils).SetConfiguredRemote(newRemote)
+            }
         }
         set successfullySavedSettings = 1
     }


### PR DESCRIPTION
Fixes a bug introduced in #768. Also, behavior is more consistent if changing git repo root directory and remote at the same time.