### PR TITLE
Sync IRIS with repo changes when switching to a remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing remotes in the git project settings pages now works if remote is not already defined (#746)
 - User-specific basic mode setting can now be changed when settingsUIReadOnly is set (#775)
 - Fixed an error displaying the Web UI after reverting a commit (#776)
+- Fixed checkout of a remote branch not syncing files with IRIS (#783)
 
 ## [2.11.0] - 2025-04-23
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1860,6 +1860,8 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
     set newArgs($increment(newArgs)) = command
 
     set syncIrisWithDiff = 0 // whether IRIS needs to be synced with repo file changes using diff output
+    set syncIrisWithDiffAfterGit = 0 // whether to sync using diff output after the git command is performed
+    set syncIrisWithDiffVerbose = 1 // whether to use verbose output when syncing using diff output
     set syncIrisWithCommand = 0 // // whether IRIS needs to be synced with repo file changes using command output
     set diffBase = ""
     set diffCompare = ""
@@ -1898,6 +1900,12 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         set syncIrisWithDiff = 1
     } elseif (command = "pull") {
         set syncIrisWithDiff = 1
+        // If performing a pull don't perform a diff until after the pull has occured.
+        // This is to avoid a double fetch, as pull performs one for us and also to avoid a potential
+        // race condition if the remote changes between now and the pull actually being performed.
+        set syncIrisWithDiffAfterGit = 1
+        // Verbose output should not be required as pull already outputs a summary
+        set syncIrisWithDiffVerbose = 0
         // The current revision, prior to the pull, will be compared against
         set diffCompare = ..GetCurrentRevision()
     } elseif (command = "merge") || (command = "rebase") {
@@ -1964,10 +1972,8 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         set syncIrisWithCommand = 0
     }
 
-    // If performing a pull don't perform a diff until after the pull has occured.
-    // This is to avoid a double fetch, as pull performs one for us and also to avoid a potential
-    // race condition if the remote changes between now and the pull actually being performed.
-    if syncIrisWithDiff && (command '= "pull") {
+    // If syncing with diff output before the git command
+    if syncIrisWithDiff && 'syncIrisWithDiffAfterGit {
         if diffBase = "" {
             set diffBase = ..GetCurrentBranch()
         }
@@ -1975,7 +1981,7 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         do ..RunGitCommand("fetch", .errorStream, .outputStream,"--prune")
         kill errorStream, outputStream
         do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errorStream,.outputStream, diffBase_$Case(diffCompare,"":"",:"..")_diffCompare, "--name-status")
-        do ..ParseDiffStream(outputStream,,.files)
+        do ..ParseDiffStream(outputStream,syncIrisWithDiffVerbose,.files)
     }
 
     set outLog = ##class(%Library.File).TempFilename()
@@ -1998,11 +2004,10 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         }
     }
 
-    // If performing a pull then do a diff now after the pull has occured.
-    if syncIrisWithDiff && (command = "pull") {
-        do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errorStream,.outputStream, diffCompare, "--name-status")
-        // Verbose output should not be required as pull already outputs a summary
-        do ..ParseDiffStream(outputStream,0,.files)
+    // If syncing with diff output after the git command
+    if syncIrisWithDiff && syncIrisWithDiffAfterGit {
+        do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("diff",,.errorStream,.outputStream, diffBase_$Case(diffCompare,"":"",:"..")_diffCompare, "--name-status")
+        do ..ParseDiffStream(outputStream,syncIrisWithDiffVerbose,.files)
     }
 
     set errStream = ##class(%Stream.FileCharacter).%OpenId(errLog,,.sc)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1890,10 +1890,14 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
 
     if (command = "checkout") {
         set syncIrisWithDiff = 1
+        // Sync using diff output after the checkout has been performed
+        // Allows syncing remote branches as the diff will otherwise fail prior
+        set syncIrisWithDiffAfterGit = 1
         if hasFileList {
             set invert = 1
         } elseif $data(args) && $data(args(args),diffCompare) {
-            // no-op
+            // Record the current branch to diff against after the checkout
+            set diffBase = ..GetCurrentBranch()
         }
     } elseif (command = "restore") {
         // Leave diffCompare empty, this actually does the right thing.
@@ -1935,12 +1939,18 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
             set newArgs($increment(newArgs)) = args(i)
             if (args(i) = "checkout") {
                 set syncIrisWithDiff = 1
+                // Sync using diff output after the checkout has been performed
+                // Allows syncing remote branches as the diff will otherwise fail prior
+                set syncIrisWithDiffAfterGit = 1
                 if hasFileList {
                     set invert = 1
                 } else {
                     set diffCompare = args(i + 1)
                     if args = (i + 2) {
                         set diffBase = args(i + 2)
+                    } else {
+                        // Record the current branch to diff against after the checkout
+                        set diffBase = ..GetCurrentBranch()
                     }
                 }
             } elseif (args(i) = "restore") {


### PR DESCRIPTION
Addresses #783 

First commit re-factors the 'diff after git command' mechanism previously added in #517 so that it can be more generically applied to other Git commands.

Second commit applies it to the checkout command.

Works with Git menu dropdown and with WebUI. The diff that was previously being applied prior to the checkout being performed would fail due to the branch not yet being local at that point in time when checking out a remote branch for the first time.