### PR TITLE
Fix initial import of settings file that has yet to be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed importing Lookup Tables that do not already exist (#791)
+- Fix initial import of settings file that has yet to be imported (#794)
 
 ## [2.12.1] - 2025-06-27
 

--- a/cls/SourceControl/Git/Settings/Document.cls
+++ b/cls/SourceControl/Git/Settings/Document.cls
@@ -102,7 +102,7 @@ Method UpdateHash(stream)
 /// or "" if the routine does not exist.
 ClassMethod TimeStamp(name As %String) As %TimeStamp
 {
-    return $get(@##class(SourceControl.Git.Utils).#Storage@("settings","TS"), $zdatetime($h,3))
+    return $get(@##class(SourceControl.Git.Utils).#Storage@("settings","TS"), "")
 }
 
 }


### PR DESCRIPTION
Fixes #794 

Do not return the current time as a timestamp when the settings file has never been imported.

Returning the current time can prevent import of the settings file as it can prevent it from being considered outdated.

The comment of the timestamp message very much suggests to me that returning `""` is the intended behaviour and that `$zdatetime($horolog,3)` is just a description of the format of the timestamp that would be returned if there was one.