### PR TITLE
When performing a pull set diffBase so that the diff to sync files with IRIS is performed in the intended direction

### DIFF
--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1911,7 +1911,7 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
         // Verbose output should not be required as pull already outputs a summary
         set syncIrisWithDiffVerbose = 0
         // The current revision, prior to the pull, will be compared against
-        set diffCompare = ..GetCurrentRevision()
+        set diffBase = ..GetCurrentRevision()
     } elseif (command = "merge") || (command = "rebase") {
         set syncIrisWithCommand = 1
         if $data(args) && $data(args(args),diffCompare) {


### PR DESCRIPTION
Fixes #802 

Setting `diffCompare` previously had the unintended result of a `..` prefix being added to the git diff command which would result in the diff being performed in the reverse direction than intended, causing additions to be treated as deletions for example.