### PR TITLE
Import embedded-git-config.json first when performing an Import All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix Import All not importing items that do not already exist when compileOnImport is not set (#798)
+- Import All now imports configuration file before everything else (#806)
 
 ## [2.12.2] - 2025-07-08
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1567,7 +1567,31 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
     
     #dim ec as %Status = ..ListItemsInFiles(.itemList, .err)
     quit:'ec ec
-
+    
+    // If there is a config file it must be imported before everything else.
+    set internalName = ""
+    for {
+        set internalName = $order(itemList(internalName))
+        quit:internalName=""
+        
+        // If a config file is found then import it
+        if internalName = ##class(SourceControl.Git.Settings.Document).#INTERNALNAME {
+            set sc = ##class(SourceControl.Git.Utils).ImportItem(internalName, force)
+            
+            if $$$ISERR(sc) {
+                set ec = $$$ADDSC(ec, sc)
+            } else {
+                kill err, itemList
+                set err = 0
+                
+                // Get the item list again as it may be different after just importing the config file
+                set ec = $$$ADDSC(ec, ..ListItemsInFiles(.itemList, .err))
+            }
+            quit
+        }
+    }
+    quit:'ec ec
+    
     kill files
     
     set settings = ##class(SourceControl.Git.Settings).%New()
@@ -1575,6 +1599,10 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
     for  {
         set internalName = $order(itemList(internalName))
         quit:internalName=""
+        
+        // Don't import the config file a second time
+        continue:internalName=##class(SourceControl.Git.Settings.Document).#INTERNALNAME
+        
         set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(internalName)
         continue:context.Package'=refPackage
         set doImport = ..IsRoutineOutdated(internalName) || force


### PR DESCRIPTION
Fixes #806 

The config file `embedded-git-config.json` is now imported first when performing an Import All.
- It is only imported once
- If it is imported then the item list is obtained again in case there are mapping configuration differences after import

This combined with some other recently merged PRs (#792, #799, #800) allows for an existing Git repository that contains a config file to be imported with the only initial configuration required being the repository location: `^SYS("SourceControl","Git","settings","namespaceTemp")` (if your Git path and other defaults are acceptable at least)