### PR TITLE
Improve config file handling in the incremental load pull event handler

### DIFF
--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -15,7 +15,8 @@ Method OnPull() As %Status
     for i=1:1:$get(..ModifiedFiles) {
         set internalName = ..ModifiedFiles(i).internalName
         if internalName = ##class(SourceControl.Git.Settings.Document).#INTERNALNAME {
-            set sc = $$$ADDSC(sc, ##class(SourceControl.Git.Utils).ImportItem(internalName))
+            set sc = $$$ADDSC(sc, ##class(SourceControl.Git.Utils).ImportItem(internalName, 1))
+            quit
         }
     }
 
@@ -23,6 +24,10 @@ Method OnPull() As %Status
 
     for i=1:1:$get(..ModifiedFiles){
         set internalName = ..ModifiedFiles(i).internalName
+        
+        // Don't import the config file a second time
+        continue:internalName=##class(SourceControl.Git.Settings.Document).#INTERNALNAME
+        
         if ((internalName = "") && (..ModifiedFiles(i).changeType '= "D")) {
             write !, ..ModifiedFiles(i).externalName, " was not imported into the database and will not be compiled. "
         } elseif (..ModifiedFiles(i).changeType = "D") {


### PR DESCRIPTION
Inspired by work on #807 

- Force import to start with as it was getting forced imported later anyway.
- Stop iterating through files once it has been imported.
- Don't import it a second time.