### PR TITLE
Do not remove deletes from the uncommitted queue when checking item status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix Import All not importing items that do not already exist when compileOnImport is not set (#798)
 - Import All now imports configuration file before everything else (#806)
+- Fixed another instance of deletes showing as owned by undefined user (#812)
 
 ## [2.12.2] - 2025-07-08
 

--- a/cls/SourceControl/Git/Change.cls
+++ b/cls/SourceControl/Git/Change.cls
@@ -66,6 +66,12 @@ ClassMethod AddDeletedToUncommitted(Filename, InternalName) As %Status
     Quit ..SetUncommitted(Filename, "delete", InternalName, $USERNAME, "", 1, "", "", 0)
 }
 
+/// Determine if an item is deleted, if it is not in a provided list of git files but is a known tracked item
+ClassMethod IsDeleted(InternalName As %String, ByRef gitFiles) As %Boolean
+{
+    Quit ('$data(gitFiles(InternalName))) && ($data($$$TrackedItems(##class(%Studio.SourceControl.Interface).normalizeName(InternalName))))
+}
+
 /// The Filename here is an ExternalName formatted name with the full file path
 ClassMethod IsUncommitted(Filename, ByRef ID) As %Boolean
 {
@@ -151,8 +157,7 @@ ClassMethod RefreshUncommitted(Display = 0, IncludeRevert = 0, Output gitFiles, 
 
         if ((InternalName = "") 
                 || ((InternalName '= "") 
-                    && ('$data(gitFiles(InternalName), found)) 
-                    && ($data($$$TrackedItems(##class(%Studio.SourceControl.Interface).normalizeName(InternalName))))))  {
+                    && ..IsDeleted(InternalName, .gitFiles)))  {
             set sc=..RemoveUncommitted(filename,Display,0,0)
             if $$$ISERR(sc) continue
         }

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -1,4 +1,4 @@
-Import SourceControl.Git
+Include SourceControl.Git
 
 /// Main source control extension class, configured namespace-wide to enable use via VSCode and Studio
 Class SourceControl.Git.Extension Extends %Studio.SourceControl.Base
@@ -529,7 +529,8 @@ Method GetStatus(ByRef InternalName As %String, ByRef IsInSourceControl As %Bool
     } else {
         // If it doesn't show up in git status, there are no uncommitted changes so it should not be locked or checked out by any user
         set Editable=1, IsCheckedOut=0, UserCheckedOut=""
-        if ##class(SourceControl.Git.Change).IsUncommitted(filename){
+        if ##class(SourceControl.Git.Change).IsUncommitted(filename)
+                && '('$data(files(InternalName)) && $data($$$TrackedItems(##class(%Studio.SourceControl.Interface).normalizeName(InternalName)))) {
             #; Remove the item from the list of uncommitted changes;
             set sc=##class(SourceControl.Git.Change).RemoveUncommitted(filename,1,1)
             if $$$ISERR(sc) write "Error removing uncommitted file "_filename_" - "_$system.OBJ.DisplayError(sc)

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -1,4 +1,4 @@
-Include SourceControl.Git
+Import SourceControl.Git
 
 /// Main source control extension class, configured namespace-wide to enable use via VSCode and Studio
 Class SourceControl.Git.Extension Extends %Studio.SourceControl.Base
@@ -530,7 +530,7 @@ Method GetStatus(ByRef InternalName As %String, ByRef IsInSourceControl As %Bool
         // If it doesn't show up in git status, there are no uncommitted changes so it should not be locked or checked out by any user
         set Editable=1, IsCheckedOut=0, UserCheckedOut=""
         if ##class(SourceControl.Git.Change).IsUncommitted(filename)
-                && '('$data(files(InternalName)) && $data($$$TrackedItems(##class(%Studio.SourceControl.Interface).normalizeName(InternalName)))) {
+           && '##class(SourceControl.Git.Change).IsDeleted(InternalName, .files) {
             #; Remove the item from the list of uncommitted changes;
             set sc=##class(SourceControl.Git.Change).RemoveUncommitted(filename,1,1)
             if $$$ISERR(sc) write "Error removing uncommitted file "_filename_" - "_$system.OBJ.DisplayError(sc)


### PR DESCRIPTION
This is another case of what was fixed in #758 

The `GetStatus` method of `SourceControl.Git.Extension` can remove deleted items from the uncommitted queue. This can make the deleted items show up as being owned by an 'undefined' user in the workspace view.

This has occurred for me in both Studio and VS Code.