### PR TITLE
Fix: Export All better handles missing items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import All now imports configuration file before everything else (#806)
 - Fixed another instance of deletes showing as owned by undefined user (#812)
 - Fix Revert not syncing files with IRIS (#789)
+- Fix "Export All" stopping prematurely because a tracked item no longer exist in the namespace (#821)
 
 ## [2.12.2] - 2025-07-08
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -982,6 +982,7 @@ ClassMethod RemoveFromServerSideSourceControl(InternalName As %String) As %Statu
 
         if $data(@..#Storage@("items", item)) {
             kill @..#Storage@("items", item)
+            do ..RemoveRoutineTSH(item)
             do ..RemoveFolderIfEmpty(..TempFolder())
         } elseif (type = "cls") {
             set tsc = ..MakeError(item _ " is not in SourceControl")
@@ -1567,7 +1568,7 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
 
     #dim ec as %Status = ..ListItemsInFiles(.itemList, .err)
     quit:'ec ec
-    
+
     // If there is a config file it must be imported before everything else.
     if $Data(itemList(##class(SourceControl.Git.Settings.Document).#INTERNALNAME)) {
         set sc = ##class(SourceControl.Git.Utils).ImportItem(##class(SourceControl.Git.Settings.Document).#INTERNALNAME, force)
@@ -1591,10 +1592,10 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
     for  {
         set internalName = $order(itemList(internalName))
         quit:internalName=""
-        
+
         // Don't import the config file a second time
         continue:internalName=##class(SourceControl.Git.Settings.Document).#INTERNALNAME
-        
+
         set context = ##class(SourceControl.Git.PackageManagerContext).ForInternalName(internalName)
         continue:context.Package'=refPackage
         set doImport = ..IsRoutineOutdated(internalName) || force
@@ -1720,7 +1721,11 @@ ClassMethod ExportItem(InternalName As %String, expand As %Boolean = 1, force As
                 write !, "Production decomposition enabled, skipping export of production class"
                 set filename = ""
             } else {
-                $$$QuitOnError($system.OBJ.ExportUDL(InternalName, filename,"-d/diff"))
+                set tSC = $SYSTEM.OBJ.ExportUDL(InternalName, filename,"-d/diff")
+                if $$$ISERR(tSC) {
+                    write !?5, InternalName, " not found.  Cleaning up source control."
+                    do ..RemoveFromServerSideSourceControl(InternalName)
+                }
             }
             if (filename '= "") && ##class(%File).Exists(filename) {
                 set filenames($I(filenames)) = filename

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1722,10 +1722,12 @@ ClassMethod ExportItem(InternalName As %String, expand As %Boolean = 1, force As
                 write !, "Production decomposition enabled, skipping export of production class"
                 set filename = ""
             } else {
-                set tSC = $SYSTEM.OBJ.ExportUDL(InternalName, filename,"-d/diff")
-                if $$$ISERR(tSC) {
+	            if '##class(%RoutineMgr).Exists(InternalName) {
                     write !?5, InternalName, " not found.  Cleaning up source control."
                     do ..RemoveFromServerSideSourceControl(InternalName)
+	            }
+	            else {
+	                $$$QuitOnError($SYSTEM.OBJ.ExportUDL(InternalName, filename,"-d/diff"))
                 }
             }
             if (filename '= "") && ##class(%File).Exists(filename) {
@@ -3287,3 +3289,4 @@ ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
 }
 
 }
+


### PR DESCRIPTION
- Fix (Export All): If a tracked item no longer exists in the namespace, remove internal tracking (#821)
    - which allows "Export all" to proceed and complete correctly.


----
I think this is good enough @isc-pbarton , but I'm open to changes if there are other things I didn't consider.