### PR TITLE
Import All outputs warning instead of error if unrecognized files found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import All now imports configuration file before everything else (#806)
 - Fixed another instance of deletes showing as owned by undefined user (#812)
 - Fix Revert not syncing files with IRIS (#789)
+- Import All now outputs a warning instead of an error when an item is in the wrong path (#291)
 
 ## [2.12.2] - 2025-07-08
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1535,7 +1535,7 @@ ClassMethod ListItemsInFiles(ByRef itemList, ByRef err) As %Status
     }
 
     if $get(err) > 0 {
-        write !, "There were some errors while importing files"
+        write !, "Warning: unrecognized files found in the sources directory:"
         for i=1:1:err {
             write !, err(i)
         }

--- a/test/UnitTest/SourceControl/Git/ImportAll.cls
+++ b/test/UnitTest/SourceControl/Git/ImportAll.cls
@@ -1,0 +1,61 @@
+Class UnitTest.SourceControl.Git.ImportAll Extends %UnitTest.TestCase
+{
+
+Property InitialExtension As %String [ InitialExpression = {##class(%Studio.SourceControl.Interface).SourceControlClassGet()} ];
+
+Property SourceControlGlobal [ MultiDimensional ];
+
+Method %OnNew(initvalue) As %Status
+{
+	Merge ..SourceControlGlobal = ^SYS("SourceControl")
+	Kill ^SYS("SourceControl")
+	Set settings = ##class(SourceControl.Git.Settings).%New()
+	Set settings.namespaceTemp = ##class(%Library.File).TempFilename()_"dir"
+	Set settings.Mappings("MAC","*")="rtn/"
+	$$$ThrowOnError(settings.%Save())
+	Do ##class(%Studio.SourceControl.Interface).SourceControlClassSet("SourceControl.Git.Extension")
+	Quit ##super(initvalue)
+}
+
+Method %OnClose() As %Status [ Private, ServerOnly = 1 ]
+{
+	Do ##class(%Studio.SourceControl.Interface).SourceControlClassSet(..InitialExtension)
+	Kill ^SYS("SourceControl")
+	Merge ^SYS("SourceControl") = ..SourceControlGlobal
+	Quit $$$OK
+}
+
+Method TestImportAll()
+{
+	do ..CreateTestRoutine()
+	$$$ThrowOnError(##class(SourceControl.Git.Utils).AddToSourceControl("test.mac"))
+	do ..CreateStrayFileInRtn()
+	$$$ThrowOnError(##class(%Routine).Delete("test.mac"))
+	$$$ThrowOnError(##class(SourceControl.Git.Utils).ImportAll(1))
+	do $$$AssertTrue(##class(%Routine).Exists("test.mac"))
+}
+
+Method CreateTestRoutine()
+{
+	if '##class(%Routine).Exists("test.mac") {
+		set r = ##class(%Routine).%New("test.mac")
+		do r.WriteLine(" write 22,!")
+		do r.Save()
+		do r.Compile()
+	}
+}
+
+/// creates a text file in the routines directory that is not really a routine
+Method CreateStrayFileInRtn()
+{
+	set fileStream = ##class(%Stream.FileCharacter).%OpenId(
+			##class(%File).NormalizeFilename(
+				"test.txt",
+				##class(%File).GetDirectory(##class(SourceControl.Git.Utils).FullExternalName("test.mac")))
+			,,.sc)
+	$$$ThrowOnError(sc)
+	$$$ThrowOnError(fileStream.Write("hello world!"))
+	$$$ThrowOnError(fileStream.%Save())
+}
+
+}


### PR DESCRIPTION
Fixes #291

Unit test does not really assert on error output, but still nice to have a little more coverage on Import All.