### PR TITLE
Fix pull failure when deleted items have no internal or external name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed Import All deploying changes to files in a CSP application (#828)
+- Fixed pull failure when deleted items have no internal or external name (#848)
 
 ## [2.13.0] - 2025-08-20
 

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -117,7 +117,7 @@ Method DeleteFile(item As %String = "", externalName As %String = "") As %Status
         $$$ThrowOnError(sc)
     } catch e {
         set filename = ##class(SourceControl.Git.Utils).FullExternalName(item)
-        if '##class(%File).Exists(filename) {
+        if (filename = "") || '##class(%File).Exists(filename) {
             do ##class(SourceControl.Git.Utils).RemoveRoutineTSH(item)
             // file doesn't exist anymore despite error -- should be ok
             set sc = $$$OK

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1329,8 +1329,14 @@ ClassMethod UpdateRoutineTSH(InternalName As %String, tsh As %String) As %Status
 
 ClassMethod RemoveRoutineTSH(InternalName As %String) As %Status
 {
-    kill @..#Storage@("TSH", ##class(%Studio.SourceControl.Interface).normalizeName(InternalName))
-    quit $$$OK
+    Quit:(InternalName = "") $$$OK
+    Set tInternalName = ##class(%Studio.SourceControl.Interface).normalizeName(InternalName)
+
+    // Prevent a possible null subscript error
+    Quit:(tInternalName = "") $$$OK
+    Kill @..#Storage@("TSH", tInternalName)
+
+    Quit $$$OK
 }
 
 ClassMethod DeleteExternalFile(InternalName As %String) As %Status


### PR DESCRIPTION
Fixes #848 

Gracefully handle `filename` or `item` being empty strings inside `##class(SourceControl.Git.PullEventHandler.IncrementalLoad).DeleteFile()`

Commit 7d52f33d0e2793492352c061d213e57c8c878cd4 causes `filename` to be an empty string more readily. Which results in the first part of the if statement being executed, if `item` is an empty string too then `##class(SourceControl.Git.Utils).RemoveRoutineTSH` will throw an exception and cause the pull to fail.

As described in fixed issue, was observed with an .xsd file that was present in a Git repo and then deleted. Pull would fail when handling the deletion of this file that had no external or internal name.