### PR TITLE
Cloning an existing repo with Configure overwrites settings from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - Unreleased
+
+### Added
+- Option to lock/unlock namespace is now available on the settings page (#650)
+
 ## [2.13.1] - 2025-09-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Option to lock/unlock namespace is now available on the settings page (#650)
 
+### Fixed
+- When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)
+
 ## [2.13.1] - 2025-09-16
 
 ### Fixed

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -454,8 +454,13 @@ Method OnAfterConfigure() As %Boolean
             set workMgr = $System.WorkMgr.%New("")
             $$$ThrowOnError(workMgr.Queue("##class(SourceControl.Git.Utils).Clone",remote))
             $$$ThrowOnError(workMgr.WaitForComplete())
-            // export settings file without committing
-            $$$ThrowOnError(..SaveWithSourceControl())
+            if ##class(%File).Exists(##class(SourceControl.Git.Utils).FullExternalName(##class(SourceControl.Git.Settings.Document).#INTERNALNAME)) {
+                write !, "Importing Embedded Git settings from cloned repository:"
+                do ##class(SourceControl.Git.Utils).ImportItem(##class(SourceControl.Git.Settings.Document).#INTERNALNAME)
+            } else {
+                // export settings file without committing
+                $$$ThrowOnError(..SaveWithSourceControl())
+            }
 
             // Empty repo breaks Embedded Git, commit the settings file
             do ##class(SourceControl.Git.Utils).RunGitCommandWithInput("log",,.errStream,.outStream)
@@ -523,4 +528,3 @@ Method SaveDefaults() As %Boolean
 }
 
 }
-

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -119,6 +119,7 @@ body {
         }
 
         if ('settings.settingsUIReadOnly) {
+            do ##class(SourceControl.Git.Utils).Locked($get(%request.Data("lockNamespace",1)))
             for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName","mappingsToken" {
                 set $Property(settings,param) = $Get(%request.Data(param,1))
             }
@@ -215,7 +216,7 @@ body {
         <strong>Success!</strong> Your changes have been saved.
     </div>
     </csp:if>
-    <form id="settingsForm" method='post'>
+    <form id="settingsForm" method='post' onsubmit="return validateForm();">
         <input type="hidden" name="Namespace" value="#(..EscapeHTML(namespace))#" />
         <input type="hidden" name="gitsettings" value="1" />
         <div class="col-sm-12"><br></div>
@@ -516,6 +517,18 @@ body {
             </div>
         </div>
         <div class="form-group row mb-3">
+            <label for="lockNamespace" class="offset-sm-1 col-sm-3 col-form-label" data-toggle="tooltip" data-placement="top" 
+                title="If true, any source-controlled code or configuration may not be directly edited in this namespace">
+                Lock Edits in Namespace</label>
+            <div class="col-sm-7">
+                <div class="custom-control custom-switch custom-switch-no-border">
+                    <input class="custom-control-input" name="lockNamespace" type="checkbox" 
+                        id="lockNamespace" #($select(##class(SourceControl.Git.Utils).Locked():"checked",1:""))# value="1">
+                    <label class="custom-control-label" for="lockNamespace"></label>
+                </div>
+            </div>
+        </div>
+        <div class="form-group row mb-3">
             <label for="mappingsToken" class="offset-sm-1 col-sm-3 col-form-label" data-toggle="tooltip" data-placement="top" title="(Optional) A namespace-specific string that may be included in mapping configurations as <token> to support multi-namespace repositories">Mappings Token</label>
             <div class="col-sm-7">
                 <input type="text" class="form-control" id="mappingsToken" name="mappingsToken" value='#(..EscapeHTML(settings.mappingsToken))#'>
@@ -804,6 +817,19 @@ function showOutput(target) {
         var msg = JSON.parse(atob(event.data.split('\r\n').join('')));
         document.getElementById(target).innerHTML += msg.content;
     }
+}
+
+function validateForm() {
+    var confirmText = "";
+    var lockNamespaceInitValue = #(''##class(SourceControl.Git.Utils).Locked())#;
+    var cbLockNamespace = document.getElementById("lockNamespace");
+    if (!cbLockNamespace) return true;
+    if (cbLockNamespace.checked && (lockNamespaceInitValue !== 1)) {
+        confirmText = "Are you sure? This will lock any source-controlled items from being edited in this namespace.";
+    } else if (!cbLockNamespace.checked && (lockNamespaceInitValue == 1)) {
+        confirmText = "Are you sure? This will allow edits of source-controlled items in this namespace.";
+    }
+    return confirmText ? confirm(confirmText) : true;
 }
 
 $(function () {

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="git-source-control.ZPM">
     <Module>
       <Name>git-source-control</Name>
-      <Version>2.13.1</Version>
+      <Version>2.14.0</Version>
       <Description>Server-side source control extension for use of Git on InterSystems platforms</Description>
       <Keywords>git source control studio vscode</Keywords>
       <Packaging>module</Packaging>


### PR DESCRIPTION
resolves #819

If the cloned repo has a settings file, its values will overwrite those chosen earlier in the Configure prompts. I agree with the requestor that this is always desired behavior.