### PR TITLE
Attempt to parse HL7 and LUT files to determine their internal name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)
 - Settings page no longer removes remote when saving after cloning (#858)
+- Fixed import of HL7 and LUT files added at the same time as their mappings (#864)
 
 ## [2.13.1] - 2025-09-16
 

--- a/cls/SourceControl/Git/File.cls
+++ b/cls/SourceControl/Git/File.cls
@@ -35,6 +35,11 @@ ClassMethod ExternalNameToInternalName(ExternalName As %String) As %String
         }
         new %SourceControl //don't trigger source hooks with this test load to get the Name
         set sc=$system.OBJ.Load(ExternalName,"-d",,.outName,1)
+        // If the test load was unsuccessful then it may be due to an unsupported
+        // file type (e.g. hl7 or lut) that we may otherwise be able to handle
+        if $$$ISERR(sc) {
+            set outName = ..ParseFileForInternalName(ExternalName)
+        }
         set itemIsPTD = 0
         if $data(outName) = 11 {
             set key = $order(outName(""))
@@ -57,6 +62,40 @@ ClassMethod ExternalNameToInternalName(ExternalName As %String) As %String
         }
     }
     quit internalName
+}
+
+/// Attempt to determine the internal name of a given file based on its content
+/// Intended to be used in situations where $system.OBJ.Load is unable to
+ClassMethod ParseFileForInternalName(fileName As %String) As %String [ Private ]
+{
+    Set internalName = ""
+    
+    Set fileExtension = $ZCONVERT($PIECE(fileName,".",*),"U")
+    If (fileExtension = "HL7") {
+        Set tSC = ##class(%XML.TextReader).ParseFile(fileName, .textReader)
+        If ($$$ISOK(tSC)) {
+            // The HL7 schema name is in the 'name' attribute of the 'Category' element
+            // Example: <Category name="...">
+            If (textReader.ReadStartElement("Category") && textReader.MoveToAttributeName("name")) {
+                If (textReader.Value '= "") {
+                    Set internalName = textReader.Value_"."_fileExtension
+                }
+            }
+        }
+    } ElseIf (fileExtension = "LUT") {
+        Set tSC = ##class(%XML.TextReader).ParseFile(fileName, .textReader)
+        If $$$ISOK(tSC) {
+            // The lookup table name is in the 'table' attribute of any 'entry' element
+            // Example: <entry table="...">
+            If (textReader.ReadStartElement("entry") && textReader.MoveToAttributeName("table")) {
+                If (textReader.Value '= "") {
+                    Set internalName = textReader.Value_"."_fileExtension
+                }
+            }
+        }
+    }
+    
+    Quit internalName
 }
 
 Storage Default


### PR DESCRIPTION
Fixes #864 (for HL7 files too)

`$system.OBJ.Load` is able to load CLS and INC files to determine their internal name. However it is not able to load the HL7 and LUT files exported by Embedded Git. These are XML files with the internal name readily available within, make an attempt to parse the file and get the internal name.

This will help avoid situations such as HL7 or LUT files being introduced at the same time as their Embedded Git mappings where the internal name was previously not able to be determined due to the mappings getting loaded in later and resulting in them not being loaded at all after a pull.

These four file types are the only types that I work with, other types may have similar issues and aren't addressed here.