### PR TITLE
Fix deployment of changes that include modification of mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)
 - Settings page no longer removes remote when saving after cloning (#858)
+- When a change includes modification to the mappings in the configuration file, the other files are deployed based on the new mappings (#864)
 
 ## [2.13.1] - 2025-09-16
 

--- a/cls/SourceControl/Git/Modification.cls
+++ b/cls/SourceControl/Git/Modification.cls
@@ -5,9 +5,6 @@ Class SourceControl.Git.Modification Extends %RegisteredObject
 /// path of the file relative to the Git repository
 Property externalName As %String;
 
-/// Name in IRIS SourceControl.Git.Modification
-Property internalName As %String;
-
 /// Type of change (A|C|D|M|R|T|U|X|B). See git diff documentation.
 Property changeType As %String;
 

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -56,8 +56,7 @@ ClassMethod ForInternalNames(InternalName As %String) As %Status
     set pointer = 0
     while $listnext(list,pointer,InternalName) {
         set mod = ##class(SourceControl.Git.Modification).%New()
-        set mod.internalName = InternalName
-        set mod.externalName = ##class(SourceControl.Git.Utils).FullExternalName(InternalName)
+        set mod.externalName = ##class(SourceControl.Git.Utils).ExternalName(InternalName)
         set mod.changeType = "M"
         set files($i(files)) = mod
     }

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -13,9 +13,8 @@ Method OnPull() As %Status
 
     // certain items must be imported before everything else.
     for i=1:1:$get(..ModifiedFiles) {
-        set internalName = ..ModifiedFiles(i).internalName
-        if internalName = ##class(SourceControl.Git.Settings.Document).#INTERNALNAME {
-            set sc = $$$ADDSC(sc, ##class(SourceControl.Git.Utils).ImportItem(internalName, 1))
+        if ..ModifiedFiles(i).externalName = ##class(SourceControl.Git.Settings.Document).#EXTERNALNAME {
+            set sc = $$$ADDSC(sc, ##class(SourceControl.Git.Utils).ImportItem(##class(SourceControl.Git.Settings.Document).#INTERNALNAME, 1))
             quit
         }
     }
@@ -23,7 +22,7 @@ Method OnPull() As %Status
     set nFiles = 0
 
     for i=1:1:$get(..ModifiedFiles){
-        set internalName = ..ModifiedFiles(i).internalName
+        set internalName = ##class(SourceControl.Git.Utils).NameToInternalName(..ModifiedFiles(i).externalName,,0)
         
         // Don't import the config file a second time
         continue:internalName=##class(SourceControl.Git.Settings.Document).#INTERNALNAME

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1631,7 +1631,6 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
             if (settings.compileOnImport) {
                 set modification = ##class(SourceControl.Git.Modification).%New()
                 set modification.changeType = "M"
-                set modification.internalName = internalName
                 set modification.externalName = ..ExternalName(internalName)
                 set files($increment(files)) = modification
             } else {
@@ -1660,7 +1659,6 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
             write !,fullExternalName," does not exist - deleting ",item
             set modification = ##class(SourceControl.Git.Modification).%New()
             set modification.changeType = "D"
-            set modification.internalName = item
             set modification.externalName = externalName
             set files($increment(files)) = modification
         }
@@ -2170,7 +2168,6 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
             set internalName = ##class(SourceControl.Git.Utils).NameToInternalName(externalName,,0)
             set modification = ##class(SourceControl.Git.Modification).%New()
             set modification.changeType = fileOperation
-            set modification.internalName = internalName
             set modification.externalName = externalName
             set files($i(files)) = modification
             if fileOperation = "A" {
@@ -2191,8 +2188,7 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
                         while $ListNext(possibleClasses,pointer,class) {
                             set modification = ##class(SourceControl.Git.Modification).%New()
                             set modification.changeType = "C"
-                            set modification.internalName = class_".CLS"
-                            set modification.externalName = ..ExternalName(modification.internalName)
+                            set modification.externalName = ..ExternalName(class_".CLS")
                             set files($i(files)) = modification
                         }
                     } else {
@@ -2206,7 +2202,6 @@ ClassMethod SyncIrisWithRepoThroughCommand(ByRef outStream) As %Status
             } else {
                 set modification = ##class(SourceControl.Git.Modification).%New()
                 set modification.changeType = "C"
-                set modification.internalName = ##class(SourceControl.Git.Utils).NameToInternalName(externalName,,0)
                 set modification.externalName = externalName
                 set files($i(files)) = modification
             }
@@ -2251,6 +2246,8 @@ ClassMethod ExpandClasses(externalName As %String) As %List
     quit classes
 }
 
+/// Parses a stream with Git diff output and returns a list of modifications.
+/// - files: output variable with an array of SourceControl.Git.Modification
 ClassMethod ParseDiffStream(stream As %Stream.Object, verbose As %Boolean = 1, Output files)
 {
     kill files
@@ -2264,22 +2261,20 @@ ClassMethod ParseDiffStream(stream As %Stream.Object, verbose As %Boolean = 1, O
         set modification.externalName = $zstrip($piece(file, $c(9), 2),"<W")
         if $extract(modification.changeType) = "R" {
             set modification.changeType = "D"
-            set modification.internalName = ##class(SourceControl.Git.Utils).NameToInternalName(modification.externalName,,0)
             set files($increment(files)) = modification
             set modification = ##class(SourceControl.Git.Modification).%New()
             set modification.changeType = "A"
-            set modification.internalName = ""
             set modification.externalName = $zstrip($piece(file, $c(9), 3),"<W")
-        } else {
-            set modification.internalName = ##class(SourceControl.Git.Utils).NameToInternalName(modification.externalName,,0)
-        }
+        } 
         set files($increment(files)) = modification
         if verbose {
-            write !, "    ", modification.changeType, "    ", modification.internalName, "    ", modification.externalName
+            write !, "    ", modification.changeType, "    ", modification.externalName
         }
     }
 }
 
+/// Loads an array of modifications from a Git diff output into IRIS.
+/// - files: an array of SourceControl.Git.Modification
 ClassMethod SyncIrisWithRepoThroughDiff(ByRef files, ByRef filterToFiles, invert As %Boolean = 0) As %Status
 {
     if invert {
@@ -2302,15 +2297,16 @@ ClassMethod SyncIrisWithRepoThroughDiff(ByRef files, ByRef filterToFiles, invert
     set deletedFiles = ""
     set addedFiles = ""
     while (key '= "") {
-        set modification = files(key)
+        #dim modification as SourceControl.Git.Modification = files(key)
         if (modification.changeType = "D") {
-            if (modification.internalName '= "") {
-                set deletedFiles = deletedFiles_","_modification.internalName
+            set internalName = ..NameToInternalName(modification.externalName,,0)
+            if (internalName '= "") {
+                set deletedFiles = deletedFiles_","_internalName
             }
         } elseif (modification.changeType = "A") {
-            set modification.internalName = ##class(SourceControl.Git.Utils).NameToInternalName(modification.externalName,,0)
-            if (modification.internalName '= "") {
-                set addedFiles = addedFiles_","_modification.internalName
+            set internalName = ##class(SourceControl.Git.Utils).NameToInternalName(modification.externalName,,0)
+            if (internalName '= "") {
+                set addedFiles = addedFiles_","_internalName
                 set files(key) = modification
             }
         }

--- a/test/UnitTest/SourceControl/Git/AbstractTest.cls
+++ b/test/UnitTest/SourceControl/Git/AbstractTest.cls
@@ -37,4 +37,11 @@ ClassMethod WriteFile(filePath, contents)
     $$$ThrowOnError(fileStream.%Save())
 }
 
+ClassMethod ResetLocalRepo()
+{
+    set localRepo = ##class(SourceControl.Git.Settings).%New().namespaceTemp
+    do ##class(%File).RemoveDirectoryTree(localRepo)
+    do ##class(%File).CreateDirectoryChain(localRepo)
+}
+
 }

--- a/test/UnitTest/SourceControl/Git/Pull.cls
+++ b/test/UnitTest/SourceControl/Git/Pull.cls
@@ -1,3 +1,4 @@
+/// Integration tests that cover deployment of changes into IRIS with git pull
 Class UnitTest.SourceControl.Git.Pull Extends UnitTest.SourceControl.Git.AbstractTest
 {
 
@@ -16,6 +17,7 @@ Method TestPull()
     do $zf(-100,"/SHELL","git", "-C", remoteDir, "add", ".")
     do $zf(-100,"/SHELL","git", "-C", remoteDir, "commit", "-m", "initial commit in remote for unit test")
     // initialize local repo, cloning remote.
+    do ..ResetLocalRepo()
     $$$ThrowOnError(##class(SourceControl.Git.Utils).Clone(remoteDir_"/.git"))
     // import all and confirm classes exist
     do $System.OBJ.Delete("TestGit.SampleClass1,TestGit.SampleClass2")
@@ -35,6 +37,92 @@ Method TestPull()
     do $$$AssertNotTrue($$$comClassDefined("TestGit.SampleClass1"))
     do $$$AssertEquals(##class(TestGit.SampleClass2).#foo, "bar")
     do $$$AssertTrue($$$comClassDefined("TestGit.SampleClass3"))
+}
+
+Method TestPullWithConfigChange()
+{
+    // initialize remote repository on filesystem
+    set remoteDir = ##class(%Library.File).TempFilename()_"d"
+    if '##class(%File).CreateDirectoryChain(remoteDir_"/data/lut",.ret) {
+        $$$ThrowStatus($$$ERROR($$$GeneralError,"failed to create directory: "_ret))
+    }
+    do ..WriteFile(remoteDir_"/embedded-git-config.json",{
+        "pullEventClass":"SourceControl.Git.PullEventHandler.Default"
+        }.%ToJSON())
+    do $zf(-100,"/SHELL","git","init",remoteDir)
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "config", "user.email", "unittest@example.com")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "config", "user.name", "Unit Test")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "add", ".")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "commit", "-m", "initial commit in remote for unit test")
+    // initialize local repo, cloning remote.
+    do ..ResetLocalRepo()
+    $$$ThrowOnError(##class(SourceControl.Git.Utils).Clone(remoteDir_"/.git"))
+    // make sure LUT does not exist to begin with
+    do ##class(%RoutineMgr).Delete("embedded-git-unit-test.lut")
+    // on remote, add a mapping for LUT and create a lookup-table.
+    do ..WriteFile(remoteDir_"/embedded-git-config.json",{
+        "pullEventClass":"SourceControl.Git.PullEventHandler.Default",
+        "Mappings": {
+            "LUT": {
+                "*": {
+                    "directory": "data/lut/",
+                    "noFolders": true
+                }
+            }
+        }
+    }.%ToJSON())
+    do ..WriteFile(remoteDir_"/data/lut/embedded-git-unit-test.lut",
+        ..SampleLUTFileContents())
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "add", ".")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "commit", "-m", "add a mapping for LUT and a LUT at the same time")
+    // pull on local and confirm mapping exists and LUT was loaded
+    $$$ThrowOnError(##class(SourceControl.Git.API).Pull())
+    do $$$AssertTrue(##class(%RoutineMgr).Exists("embedded-git-unit-test.lut"))
+    do $$$AssertEquals($get(^SYS("SourceControl","Git","settings","mappings","LUT","*")), "data/lut/")
+    do ##class(%RoutineMgr).Delete("embedded-git-unit-test.lut")
+}
+
+Method TestPullWithRename()
+{
+    // initialize remote repository on filesystem
+    set remoteDir = ##class(%Library.File).TempFilename()_"d"
+    if '##class(%File).CreateDirectoryChain(remoteDir_"/cls",.ret) {
+        $$$ThrowStatus($$$ERROR($$$GeneralError,"failed to create directory: "_ret))
+    }
+    set settings = ##class(SourceControl.Git.Settings).%New()
+    set settings.Mappings("LUT","*") = "data/lut/"
+    set settings.Mappings("LUT","*","NoFolders") = 1
+    do settings.%Save()
+    do ..WriteFile(remoteDir_"/data/lut/embedded-git-unit-test.lut", ..SampleLUTFileContents())
+    do $zf(-100,"/SHELL","git","init",remoteDir)
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "config", "user.email", "unittest@example.com")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "config", "user.name", "Unit Test")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "add", ".")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "commit", "-m", "initial commit in remote for unit test")
+    // initialize local repo, cloning remote.
+    do ..ResetLocalRepo()
+    $$$ThrowOnError(##class(SourceControl.Git.Utils).Clone(remoteDir_"/.git"))
+    // import all and confirm LUT exists
+    $$$ThrowOnError(##class(SourceControl.Git.Utils).ImportAll(1))
+    do $$$AssertTrue(##class(%RoutineMgr).Exists("embedded-git-unit-test.lut"))
+    // rename the LUT on the remote
+    if '##class(%File).Rename(remoteDir_"/data/lut/embedded-git-unit-test.lut",remoteDir_"/data/lut/embedded-git-unit-test-2.lut",.ret) {
+        $$$ThrowStatus($$$ERROR($$$GeneralError,"failed to rename LUT file: "_ret))
+    }
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "add", ".")
+    do $zf(-100,"/SHELL","git", "-C", remoteDir, "commit", "-m", "delete, modify, and add classes on remote")
+    // pull on local and confirm LUT was updated
+    $$$ThrowOnError(##class(SourceControl.Git.API).Pull())
+    do $$$AssertNotTrue(##class(%RoutineMgr).Exists("embedded-git-unit-test.lut"))
+    do $$$AssertTrue(##class(%RoutineMgr).Exists("embedded-git-unit-test-2.lut"))
+}
+
+ClassMethod SampleLUTFileContents() As %String
+{
+    return "<?xml version=""1.0""?>"_$c(13,10)_ 
+        "<lookupTable>"_$c(13,10)_ 
+        "<entry table=""pbarton"" key=""foo"">bar</entry>"_$c(13,10)_ 
+        "</lookupTable>"
 }
 
 }


### PR DESCRIPTION
Fixes #864 

Previously internal names for items in a deployment were all calculated at once before the import. Now they are lazily calculated when we import the individual item. Since we deploy changes to the configuration file first, this means changes to mappings are correctly taken into account.