### PR TITLE
Always set the remote as the upstream branch when pushing, for consistency with Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)
 - Settings page no longer removes remote when saving after cloning (#858)
+- Always set the remote as the upstream branch when pushing (#871)
 
 ## [2.13.1] - 2025-09-16
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -616,6 +616,7 @@ ClassMethod Push(remote As %String = "origin", force As %Boolean = 0) As %Status
     if (force) {
         set args($i(args)) = "--force"
     }
+    set args($i(args)) = "--set-upstream"
     set args($i(args)) = remote
     set args($i(args)) = branchName
     do ..RunGitWithArgs(.errStream, .outStream, "push", args...)


### PR DESCRIPTION
Fixes #871

Always specify `--set-upstream` when pushing for consistency with Web UI which always sets `-u` (the shorthand equivalent).

Can't think of any reason not to do this and the various ways to push should have consistent behaviour anyway.

The following is the existing Web UI code, for reference:
https://github.com/intersystems/git-source-control/blob/18999e9321201636a219b42922d460ba16a42ca8/git-webui/release/share/git-webui/webui/js/git-webui.js#L935