### PR TITLE
Add setting for SSH client configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings page now warns if Embedded Git is not the configured source control extension (#857)
 - Settings page now has option to switch namespace (#856)
 - SourceControl.Git.Settings is now documented as part of the public API to allow programmatic configuration of settings (#262)
+- New setting to define an SSH client configuration file for connections to SSH remotes (#293)
 
 ### Fixed
 - When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)

--- a/cls/SourceControl/Git/Settings.cls
+++ b/cls/SourceControl/Git/Settings.cls
@@ -93,6 +93,9 @@ Property Mappings [ MultiDimensional ];
 /// (user-level) List of namespaces on this instance to include Embedded Git links in the SMP favorites
 Property favoriteNamespaces As %DynamicArray;
 
+/// (Optional) Path to an SSH client configuration file for use with SSH connections to a Git remote
+Property sshConfigFile As %String(MAXLEN = "") [ InitialExpression = {##class(SourceControl.Git.Utils).SSHConfigFile()} ];
+
 Method %OnNew() As %Status
 {
     set mappingsNode = ##class(SourceControl.Git.Utils).MappingsNode()
@@ -183,6 +186,7 @@ Method %Save() As %Status
     set @storage@("settings", "environmentName") = ..environmentName
     set @storage@("settings", "lockBranch") = ..lockBranch
     set @storage@("settings", "mappingsToken") = ..mappingsToken
+    set @storage@("settings", "sshConfigFile") = ..sshConfigFile
     if ..basicMode = "system" {
         kill @storage@("settings", "user", $username, "basicMode")
     } else {
@@ -551,3 +555,4 @@ Method SaveDefaults() As %Boolean
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -195,6 +195,11 @@ ClassMethod MappingsToken() As %String
     quit $get(@..#Storage@("settings","mappingsToken"),"")
 }
 
+ClassMethod SSHConfigFile() As %String
+{
+    quit $get(@..#Storage@("settings","sshConfigFile"),"")
+}
+
 ClassMethod IsLIVE() As %Boolean
 {
     quit ..EnvironmentName()="LIVE"
@@ -1896,8 +1901,14 @@ ClassMethod RunGitCommandWithInput(command As %String, inFile As %String = "", O
                 set privateKeyFile = $replace(privateKeyFile,"\","\\")
             }
             set newArgs($increment(newArgs)) = "-c"
+            set sshConfigFile = ..SSHConfigFile()
+            if sshConfigFile="" {
+                set sshConfigFile = "/dev/null"
+            } elseif $$$isWINDOWS {
+                set sshConfigFile = $replace(sshConfigFile,"\","\\")
+            }
             // StrictHostKeyChecking=accept-new for good behavior on first connection
-            set newArgs($increment(newArgs)) = "core.sshCommand=ssh -F /dev/null -o StrictHostKeyChecking=accept-new -i "_privateKeyFile
+            set newArgs($increment(newArgs)) = "core.sshCommand=ssh -F "_sshConfigFile_" -o StrictHostKeyChecking=accept-new -i "_privateKeyFile
         }
 
         set username = ""
@@ -3320,3 +3331,4 @@ ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
 }
 
 }
+

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -120,7 +120,7 @@ body {
 
         if ('settings.settingsUIReadOnly) {
             do ##class(SourceControl.Git.Utils).Locked($get(%request.Data("lockNamespace",1)))
-            for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName","mappingsToken" {
+            for param="gitBinPath","namespaceTemp","privateKeyFile","pullEventClass","percentClassReplace", "defaultMergeBranch","environmentName","mappingsToken","sshConfigFile" {
                 set $Property(settings,param) = $Get(%request.Data(param,1))
             }
 
@@ -394,6 +394,13 @@ body {
             }
         }
         </server>
+
+        <div class="form-group row mb-3">
+            <label for="sshConfigFile" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="(Optional) Path to an SSH client configuration file for use with SSH connections to a Git remote">Path to SSH Config File</label>
+            <div class="col-sm-7">
+                <input type="text" class="form-control" id="sshConfigFile" name="sshConfigFile" value='#(..EscapeHTML(settings.sshConfigFile))#' placeholder=""/>
+            </div>
+        </div>
 
         <div class="form-group row mb-3">
             <label for="pullEventClass" class="offset-sm-1 col-sm-3 col-form-label"  data-toggle="tooltip" data-placement="top" title="Handler class for git pull"><b>Pull Event Class</b></label>


### PR DESCRIPTION
Resolves #293

A testing plan:
Clone a GitHub repository via SSH with a private key file. Settings page should say "connection successful" under the Remote Repository input.
Create a new config file with contents matching those suggested here: https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port#enabling-ssh-connections-over-https
Set the "Path to SSH Config File" in settings to that file path and save. It should still say "connection successful".
Set the path to a nonexistent file. It should show an error message under the Remote Repository input.
Clear the value. It should say "connection successful" again.