### PR TITLE
Changed compile flags used by pull event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings page now has option to switch namespace (#856)
 - SourceControl.Git.Settings is now documented as part of the public API to allow programmatic configuration of settings (#262)
 - New setting to define an SSH client configuration file for connections to SSH remotes (#293)
+- Changed default compilation flags from "ck" to "ckbryu" to include related items (#882)
 
 ### Fixed
 - When cloning a repo with Configure, that repo's embedded-git-config file will overwrite previous settings (#819)

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -52,7 +52,7 @@ Method OnPull() As %Status
         write !, "Nothing to compile."
         quit $$$OK
     }
-    set sc = $$$ADDSC(sc,$system.OBJ.CompileList(.compilelist, "ck"))
+    set sc = $$$ADDSC(sc,$system.OBJ.CompileList(.compilelist, "ckbryu"))
     // after compilation, deploy any PTD items
     set key = $order(ptdList(""))
     while (key '= "") {


### PR DESCRIPTION
resolves #882 

When doing a Git pull, switch branch, import all, etc. we know compile imported items with some additional flags:
- bry: Compile more dependent classes
- u: Do not compile if the class is already up-to-date