### PR TITLE
Storage definition changes export to Git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Web UI workspace view labels changes as Merge Conflict if there are unmerged changes (#890)
 - Web UI workspace view displays diff correctly for files with merge conflicts (#898)
+- Storage definition changes in persistent classes are now correctly exported to the Git repository (#906)
 
 ## [2.14.0] - 2025-11-07
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -441,6 +441,22 @@ Method OnAfterDelete(InternalName As %String) As %Status
     quit $$$OK
 }
 
+/// This is called if you compile a class and the compilation updates the class storage.
+/// It is called after the storage has been updated so you can determine how to deal with this
+/// change in the class. The <var>Location</var> is the global reference to the class definition that was changed.
+Method OnAfterStorage(InternalName As %String, Location As %String = "") As %Status
+{
+    if (InternalName '= "") {
+        write !,"Item '"_InternalName_"' changed during compile so exporting new version."
+        set ..Modified(InternalName) = 1
+        set sc = ..OnAfterSave(InternalName)
+        if $$$ISERR(sc) {
+            do $System.OBJ.DisplayError(sc)
+        }
+    }
+    return $$$OK
+}
+
 /// Convert the internal name, e.g. TEST.MAC, to an external name that is used to export
 /// the routine/class/csp item. This is often a filename to write the file out to.
 Method ExternalName(InternalName As %String) As %String


### PR DESCRIPTION
fixes #906

Tested:
- editing a persistent class to add a new property, storage definition in git repo is updated after save
- editing a persistent class to add a new parameter, export after save still works and is not called twice
- editing a non-persistent class, export after save still works and is not called twice