### PR TITLE
GetStatus correctly marks generated files read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.1] - Unreleased
+
+## Fixed
+- Fixed issue where Generated Files Read-only option didn't entirely work for files not in source control (#712)
+
 ## [2.15.0] - 2026-01-06
 
 ### Added

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -546,7 +546,7 @@ Method GetStatus(ByRef InternalName As %String, ByRef IsInSourceControl As %Bool
         }
     } else {
         // If it doesn't show up in git status, there are no uncommitted changes so it should not be locked or checked out by any user
-        set Editable=1, IsCheckedOut=0, UserCheckedOut=""
+        set IsCheckedOut=0, UserCheckedOut=""
         if ##class(SourceControl.Git.Change).IsUncommitted(filename)
            && '##class(SourceControl.Git.Change).IsDeleted(InternalName, .files) {
             #; Remove the item from the list of uncommitted changes;
@@ -590,4 +590,3 @@ Method CheckBusinessProcessesAndRules(InternalName As %String) As %Status
 }
 
 }
-

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="git-source-control.ZPM">
     <Module>
       <Name>git-source-control</Name>
-      <Version>2.15.0</Version>
+      <Version>2.15.1</Version>
       <Description>Server-side source control extension for use of Git on InterSystems platforms</Description>
       <Keywords>git source control studio vscode</Keywords>
       <Packaging>module</Packaging>

--- a/test/UnitTest/SourceControl/Git/Extension.cls
+++ b/test/UnitTest/SourceControl/Git/Extension.cls
@@ -19,10 +19,13 @@ Method TestGeneratedFilesReadOnlyOption()
         $$$ThrowOnError(settings.%Save())
         set extension = ##class(SourceControl.Git.Extension).%New("")
         do $$$AssertNotTrue(extension.IsReadOnly("UnitTest.SourceControl.Git.GeneratedReadOnly.cls"))
-
+        do extension.GetStatus("UnitTest.SourceControl.Git.GeneratedReadOnly.cls",,.editable)
+        do $$$AssertTrue(editable)
         set settings.generatedFilesReadOnly = 1
         $$$ThrowOnError(settings.%Save())
         do $$$AssertTrue(extension.IsReadOnly("UnitTest.SourceControl.Git.GeneratedReadOnly.cls"))
+        do extension.GetStatus("UnitTest.SourceControl.Git.GeneratedReadOnly.cls",,.editable)
+        do $$$AssertNotTrue(editable)
     } catch err {
         set sc = err.AsStatus()
     }


### PR DESCRIPTION
Fixes ##712

You are now warned as soon as you open a generated file in Studio that it is marked as read-only. Previously it would only stop you from editing once you tried making a change.