### PR TITLE
Add settings toggle for instance-wide uncommitted warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Baseline Export now includes decomposed production items when production decomposition is enabled (#680)
 - Take Ownership option in source control menu allows you to take ownership of an item edited by another user (#926)
+- The "warnInstanceWideUncommitted" option can now be changed through the settings page (#936)
 
 ## Fixed
 - Fixed `<VALUE OUT OF RANGE>` error in GetTempFileAndRoutineTS when an OS-level error code was stored as a routine timestamp (#832)

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -141,6 +141,7 @@ body {
             set settings.decomposeProductions = ($Get(%request.Data("decomposeProductions", 1)) = 1)
             set settings.decomposeProdAllowIDE = ($Get(%request.Data("decomposeProdAllowIDE", 1)) = 1)
             set settings.lockBranch = ($Get(%request.Data("lockBranch", 1)) = 1)
+            set settings.warnInstanceWideUncommitted = ($Get(%request.Data("warnInstanceWideUncommitted", 1)) = 1)
 
             if ($Get(%request.Data("systemBasicMode", 1)) = 1) {
                 set settings.systemBasicMode = 1
@@ -576,6 +577,18 @@ body {
                     <input class="custom-control-input" name="lockNamespace" type="checkbox" 
                         id="lockNamespace" #($select(##class(SourceControl.Git.Utils).Locked():"checked",1:""))# value="1">
                     <label class="custom-control-label" for="lockNamespace"></label>
+                </div>
+            </div>
+        </div>
+        <div class="form-group row mb-3">
+            <label for="warnInstanceWideUncommitted" class="offset-sm-1 col-sm-3 col-form-label" data-toggle="tooltip" data-placement="top"
+                title="Show a warning when opening an item that has uncommitted changes in a different namespace in this instance">
+                Warn Instance-Wide Uncommitted</label>
+            <div class="col-sm-7">
+                <div class="custom-control custom-switch custom-switch-no-border">
+                    <input class="custom-control-input" name="warnInstanceWideUncommitted" type="checkbox"
+                        id="warnInstanceWideUncommitted" #($select(settings.warnInstanceWideUncommitted:"checked",1:""))# value="1">
+                    <label class="custom-control-label" for="warnInstanceWideUncommitted"></label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Resolves #936
Tested by toggling the setting in the UI, saving, confirming the setting was saved in the backend.