### PR TITLE
enh: include cross-namespace IPM packages in contexts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Import of decomposed production items now has a brief timeout in case another deploy is in progress (#949)
+- Change context menu now lists IPM packages from all Git-enabled namespaces, prefixed with the namespace name (#952)
 
 ### Fixed
 - Changes to % routines mapped to the current namespace may now be added to source control and committed (#944)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2807,18 +2807,28 @@ ClassMethod GetContexts(onlyNamespaces As %Boolean) As %DynamicArray
 
     set name = ""
 
-    // Using embedded for backwards compatability
+    // Using embedded instead of ExecDirectNoPriv() for backwards compatability
     if '(onlyNamespaces) {
         &sql(DECLARE C1 CURSOR FOR SELECT name into :name from %Library.RoutineMgr_StudioOpenDialog('*.ZPM'))
-        &sql(OPEN C1)
-            throw:SQLCODE<0 ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE, %msg)
-        &sql(FETCH C1)
-        while(SQLCODE = 0) {
-            set package = name
-            do contexts.%Push(package)
-            &sql(FETCH C1)
+        new $namespace
+        set ptr = 0
+        while $listnext(namespaces,ptr,ns) {
+            if '($FIND(ns,"^^")) {
+                try {
+                    set $NAMESPACE = ns
+                    &sql(OPEN C1)
+                    throw:SQLCODE<0 ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE, %msg)
+                    &sql(FETCH C1)
+                    while (SQLCODE = 0) {
+                        do contexts.%Push(ns_":"_name)
+                        &sql(FETCH C1)
+                    }
+                    &sql(CLOSE C1)
+                } catch e {
+                    // skip inaccessible namespaces
+                }
+            }
         }
-        &sql(CLOSE C1)
     }
 
     return contexts
@@ -3391,3 +3401,4 @@ ClassMethod IsSchemaStandard(pName As %String = "") As %Boolean [ Internal ]
 }
 
 }
+

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2817,7 +2817,7 @@ ClassMethod GetContexts(onlyNamespaces As %Boolean) As %DynamicArray
                 try {
                     set $NAMESPACE = ns
                     &sql(OPEN C1)
-                    throw:SQLCODE<0 ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE, %msg)
+                    throw:(SQLCODE<0) ##class(%Exception.SQL).CreateFromSQLCODE(SQLCODE, %msg)
                     &sql(FETCH C1)
                     while (SQLCODE = 0) {
                         do contexts.%Push(ns_":"_name)

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -701,7 +701,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
         var args = window.location.href.split("webuidriver.csp/")[1].split("/");
         var context = args[0];
         if (args[1] && (args[1].indexOf(".ZPM") != -1)) {
-            context = args[1];
+            context = args[0] + ":" + args[1];
         }
         return context;
     }
@@ -710,7 +710,9 @@ webui.SideBarView = function(mainView, noEventHandlers) {
         var urlParts = window.location.href.split("webuidriver.csp/");
         var args = urlParts[1].split("/");
         if (context.indexOf(".ZPM") != -1) {
-            args[1] = context;
+            var parts = context.split(":");
+            args[0] = parts[0];
+            args[1] = parts[1];
         } else {
             args[0] = context;
             args[1] = "";

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -698,6 +698,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
     }
 
     self.getCurrentContext = function() {
+        // URL pattern here is like webuidriver.csp/<namespace>/<InternalName of selected item>
         var args = window.location.href.split("webuidriver.csp/")[1].split("/");
         var context = args[0];
         if (args[1] && (args[1].indexOf(".ZPM") != -1)) {

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -701,7 +701,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
         var args = window.location.href.split("webuidriver.csp/")[1].split("/");
         var context = args[0];
         if (args[1] && (args[1].indexOf(".ZPM") != -1)) {
-            context = args[1];
+            context = args[0] + ":" + args[1];
         }
         return context;
     }
@@ -710,7 +710,9 @@ webui.SideBarView = function(mainView, noEventHandlers) {
         var urlParts = window.location.href.split("webuidriver.csp/");
         var args = urlParts[1].split("/");
         if (context.indexOf(".ZPM") != -1) {
-            args[1] = context;
+            var parts = context.split(":");
+            args[0] = parts[0];
+            args[1] = parts[1];
         } else {
             args[0] = context;
             args[1] = "";

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -698,6 +698,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
     }
 
     self.getCurrentContext = function() {
+        // URL pattern here is like webuidriver.csp/<namespace>/<InternalName of selected item>
         var args = window.location.href.split("webuidriver.csp/")[1].split("/");
         var context = args[0];
         if (args[1] && (args[1].indexOf(".ZPM") != -1)) {


### PR DESCRIPTION
Resolves #952 

Manual testing:

- docker compose up --build
- Create a second namespace in the container
- Set SourceControl.Git.Extension as source control extension for both namespaces
- git clone TestCoverage repo twice into separate directories in the container
- zpm "load -dev" each repo into a separate namespace
- Viewed Git Web UI, confirmed change context menu has options for USER:TESTCOVERAGE.ZPM and PBARTON:TESTCOVERAGE.ZPM
- Make a change in one of the repos. Switch back and forth between the two contexts in web ui and confirmed the workspace view updated.