### PR TITLE
Fixed GitHub actions build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install IPM
         run: |
-          echo 's version="0.10.6" s r=##class(%Net.HttpRequest).%New(),r.Server="pm.community.intersystems.com",r.SSLConfiguration="ISC.FeatureTracker.SSL.Config" d r.Get("/packages/zpm/"_version_"/installer"),$system.OBJ.LoadStream(r.HttpResponse.Data,"c")' > install-ipm
+          echo 's version="latest" s r=##class(%Net.HttpRequest).%New(),r.Server="pm.community.intersystems.com",r.SSLConfiguration="ISC.FeatureTracker.SSL.Config" d r.Get("/packages/zpm/"_version_"/installer"),$system.OBJ.LoadStream(r.HttpResponse.Data,"c")' > install-ipm
           docker exec --interactive $instance iris session $instance -B < install-ipm
           echo "zpm \"enable -community\":1:1" > config-registry
           docker exec --interactive $instance iris session $instance -B < config-registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       
       # ** FOR GENERAL USE, LIKELY NEED TO CHANGE **
       package: git-source-control
-      container_image: intersystemsdc/iris-community:latest
+      container_image: containers.intersystems.com/intersystems/iris-community:latest-cd
       
       # ** FOR GENERAL USE, MAY NEED TO CHANGE **
       build_flags: -dev -verbose
@@ -59,6 +59,16 @@ jobs:
           # Wait for instance to be ready
           until docker exec --interactive $instance iris session $instance < wait; do sleep 1; done
       
+      - name: Install Git
+        run: docker exec --user root $instance bash -c "apt-get update && apt-get install -y git"
+
+      - name: Install IPM
+        run: |
+          echo 's version="0.10.6" s r=##class(%Net.HttpRequest).%New(),r.Server="pm.community.intersystems.com",r.SSLConfiguration="ISC.FeatureTracker.SSL.Config" d r.Get("/packages/zpm/"_version_"/installer"),$system.OBJ.LoadStream(r.HttpResponse.Data,"c")' > install-ipm
+          docker exec --interactive $instance iris session $instance -B < install-ipm
+          echo "zpm \"enable -community\":1:1" > config-registry
+          docker exec --interactive $instance iris session $instance -B < config-registry
+
       - name: Install TestCoverage
         run: |
           echo "zpm \"install testcoverage\":1:1" > install-testcoverage


### PR DESCRIPTION
The CI in GitHub Actions was failing with a mysterious core dump when it tried to install TestCoverage. Switching from the intersystemsdc image to the containers.intersystems.com image fixes it.


```
04/16/26-20:48:53:042 (1477) 1 [Generic.Event] Argument stack incorrect: -16 at line 1539 of ^%IPM.Lifecycle.Base.1 from sfn 7 /usr/irissys/mgr/zpm/
04/16/26-20:48:53:045 (1477) 3 [Generic.Event] Process 1477 (JobType=Callin Connection,Dumpstyle=0,Directory='/usr/irissys/mgr/user/') caught signal 11.
04/16/26-20:48:53:046 (1477) 3 [Generic.Event] Parent process will clean up and halt
04/16/26-20:48:53:046 (1477) 3 [Generic.Event] If core dumps are enabled, a core file will be created by process 1479 in the location specified by the system configuration.
04/16/26-20:48:53:046 (1477) 0 [Generic.Event] inconsistency detected in 'inuse cls' table, dead job cleanup ignored it - 31
04/16/26-20:48:53:048 (1302) 2 [Generic.Event] Process terminated abnormally (pid 1477, jobid 0x0003000d) (Halted with an open transaction)
04/16/26-20:48:53:048 (1302) 0 [Generic.Event] cleaned dead job, pid: 1477, jobid 0x0003000d
04/16/26-20:48:57:948 (1301) 2 [Utility.Event] Process 1302 generated 3 alerts in 10 seconds. Suspending alert notifications for this process.
```