### PR TITLE
feat: user-friendly display of pull event handler name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import of decomposed production items now has a brief timeout in case another deploy is in progress (#949)
 - Option to view an individual file's history in the source control menu (#960)
 - Change context menu now lists IPM packages from all Git-enabled namespaces, prefixed with the namespace name (#952)
+- Pull event handler option in settings page now displays user-friendly names for options (#908)
 
 ### Fixed
 - Changes to % routines mapped to the current namespace may now be added to source control and committed (#944)

--- a/csp/gitprojectsettings.csp
+++ b/csp/gitprojectsettings.csp
@@ -417,8 +417,15 @@ body {
                         set rs = ##class(%Dictionary.ClassDefinition).SubclassOfFunc("SourceControl.Git.PullEventHandler")
                         while rs.%Next() {
                             set subclass = rs.%GetData(1)
+                            try {
+                                set name = $parameter(subclass,"NAME")
+                                set title = $PIECE(subclass, ".", *-0) _ ": " _ $parameter(subclass,"DESCRIPTION")
+                            } catch err {
+                                // in the unlikely case of an error, fall back to class name
+                                set name = subclass, title = ""
+                            }
                             // create option with subclass, set selected if subclass == current pullEventClass
-                            &html<<option value=#(subclass)# #($CASE(subclass, settings.pullEventClass: "selected", :""))#>#($PIECE(subclass, ".", *-0))# </option>>
+                            &html<<option title="#(..EscapeHTML(title))#" value=#(subclass)# #($CASE(subclass, settings.pullEventClass: "selected", :""))#>#(..EscapeHTML(name))# </option>>
                         }
                     </server>
                 </select>


### PR DESCRIPTION
## Description
Resolves #908

The "Pull Event Handler" dropdown in the Embedded Git settings page now displays the user-friendly name for options as specified by the NAME parameter instead of the class name. Hover text on the options displays the class name and the description.

## Testing

```
docker compose up --build -d
```
Visited http://localhost:52774/isc/studio/usertemplates/gitsourcecontrol/gitprojectsettings.csp and tested viewing and changing the pull event handler input. Tested saving the form and confirmed it persisted.
<img width="1461" height="351" alt="image" src="https://github.com/user-attachments/assets/2d03af6f-5c58-4726-8787-e98a95e90e12" />


## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.