### PR TITLE
ImportAll work queue manager to import items in parallel in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.17.0] - Unreleased
 
 ### Added
+- `ImportAll` imports items in parallel when `compileOnImport` and `decomposeProductions` are both disabled, reducing import time for large codebases (#970)
 - Import of decomposed production items now has a brief timeout in case another deploy is in progress (#949)
 - Option to view an individual file's history in the source control menu (#960)
 - Change context menu now lists IPM packages from all Git-enabled namespaces, prefixed with the namespace name (#952)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1672,9 +1672,9 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
     set settings = ##class(SourceControl.Git.Settings).%New()
 
     // Create a work queue manager to use for importing items to improve performance
-    // Currently only used when not compiling
+    // Currently only used when not compiling and not using decomposed productions
     #dim queue as %SYSTEM.WorkMgr = ""
-    if ('settings.compileOnImport) {
+    if ('settings.compileOnImport && 'settings.decomposeProductions) {
         set queue = ##class(%SYSTEM.WorkMgr).%New()
         if (queue = "") {
             set ec = $$$ADDSC(ec, %objlasterror)

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1670,6 +1670,18 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
     kill files
 
     set settings = ##class(SourceControl.Git.Settings).%New()
+
+    // Create a work queue manager to use for importing items to improve performance
+    // Currently only used when not compiling
+    #dim queue as %SYSTEM.WorkMgr = ""
+    if ('settings.compileOnImport) {
+        set queue = ##class(%SYSTEM.WorkMgr).%New()
+        if (queue = "") {
+            set ec = $$$ADDSC(ec, %objlasterror)
+            quit:'ec ec
+        }
+    }
+
     #dim internalName as %String = ""
     for  {
         set internalName = $order(itemList(internalName))
@@ -1697,7 +1709,13 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
                 set files($increment(files)) = modification
             } else {
                 // If not compiling then import now as otherwise it won't happen
-                set sc = ..ImportItem(internalName, force)
+                set sc = $$$OK
+                // If a work queue has been created then use it
+                if (queue '= "") {
+                    set sc = queue.Queue("..ImportItem", internalName, force)
+                } else {
+                    set sc = ..ImportItem(internalName, force)
+                }
                 if $$$ISERR(sc) {
                     set ec = $$$ADDSC(ec, sc)
                 }
@@ -1705,6 +1723,13 @@ ClassMethod ImportRoutines(force As %Boolean = 0, pullEventClass As %String) As 
         }
     }
 
+    // If a work queue was created then wait for all work to finish
+    if (queue '= "") {
+        set sc = queue.Sync()
+        if $$$ISERR(sc) {
+            set ec = $$$ADDSC(ec, sc)
+        }
+    }
 
     //let's delete all items for which corresponding files had been deleted
     #dim item as %String = ""


### PR DESCRIPTION
## Description
Import All is currently all done in a single thread and with a large codebase this becomes a bottleneck as for example it can take 10+ minutes to import to import 6000+ files. We have a CI/CD pipeline where we use `ImportAll` dozens a times a day and `ImportAll` is the step that currently takes the most time.

We do not use `compileOnImport` or `decomposeProductions` at all and so the scope has purposely been limited to only cover when those options are *not* being used. In this case it seems to be relatively straightforward to apply a work queue manager so that `ImportItem` is performed in parallel.

This has yielded significant improvements with importing being 3-4 times faster. When system processes are observed using `top` multiple `irisdb` proceses are observed churning away with high CPU usage (as expected), rather than only a single process prior.

It is very likely possible to re-factor `ImportRoutines` so that more can be done in parallel but the current code structure makes it straightforward to apply this to `ImportItem` which seems to be where most of the heavy lifting is currently done anyway and so likely the most benefit derived.

To allow a work queue manager to be used with `compileOnImport` would probably require a separate implementation within the pull event handler itself, which is not planned as part of this work due to not using this setting. To use with `decomposeProductions` would probably require additional locking to be implemented in `ImportItem` to allow productions to be created and updated safely, also not planned as part of this due to not using this setting - it is conceivable that such a thing may help with #917 .

## Testing
Tested manually with a codebase that consists of 6000+ files (includes types `.cls`, `.hl7`, `.inc` and `.lut`), importing all from scratch (i.e. fresh empty IRIS container) and subsequent *Import All (Force)* over the top repeatedly. With and without `compileOnImport` and `decomposeProductions` enabled to check that work queue manager is and isn't being used as expected. Compiling all classes and running unit tests without any expected issues after work manager import all.

## Checklist
- [Y] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [N/A] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
