### PR TITLE
Fix invalid regular expression in branch name special character check

### DIFF
--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -472,9 +472,18 @@ webui.SideBarView = function(mainView, noEventHandlers) {
             }
             var cardDiv = $('<div class="card custom-card branch-card">').appendTo(accordionDiv)[0];
             if (id.indexOf("local-branches") > -1) {
+                // Remove any '^' prefix or '$' suffix from the branch name regex
+                // So that it can be inserted into the middle of another regex below
+                var branchNamePattern = webui.branchNamePattern.source
+                if (branchNamePattern.substring(0, 1) == "^") {
+                  branchNamePattern = branchNamePattern.substring(1, branchNamePattern.length)
+                }
+                if (branchNamePattern.substring(branchNamePattern.length-1, branchNamePattern.length) == "$") {
+                  branchNamePattern = branchNamePattern.substring(0, branchNamePattern.length-1)
+                }
                 // parses the output of git branch --verbose --verbose
                 // only match branch names with supported characters (see webui.branchNamePattern)
-                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ webui.branchNamePattern.source.substring(1,webui.branchNamePattern.source.length-1) +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
+                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ branchNamePattern +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
                 var matches = reMatchGitBranchOutput.exec(ref);
                 if (!matches) {
                     $(cardDiv).remove();

--- a/git-webui/release/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/release/share/git-webui/webui/js/git-webui.js
@@ -474,7 +474,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
             if (id.indexOf("local-branches") > -1) {
                 // parses the output of git branch --verbose --verbose
                 // only match branch names with supported characters (see webui.branchNamePattern)
-                var reMatchGitBranchOutput = new RegExp("^\*?\s*("+ webui.branchNamePattern.source +")\s+([^\s]+)\s+(\[.*\])?.*")
+                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ webui.branchNamePattern.source.substring(1,webui.branchNamePattern.source.length-1) +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
                 var matches = reMatchGitBranchOutput.exec(ref);
                 if (!matches) {
                     $(cardDiv).remove();

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -472,9 +472,18 @@ webui.SideBarView = function(mainView, noEventHandlers) {
             }
             var cardDiv = $('<div class="card custom-card branch-card">').appendTo(accordionDiv)[0];
             if (id.indexOf("local-branches") > -1) {
+                // Remove any '^' prefix or '$' suffix from the branch name regex
+                // So that it can be inserted into the middle of another regex below
+                var branchNamePattern = webui.branchNamePattern.source
+                if (branchNamePattern.substring(0, 1) == "^") {
+                  branchNamePattern = branchNamePattern.substring(1, branchNamePattern.length)
+                }
+                if (branchNamePattern.substring(branchNamePattern.length-1, branchNamePattern.length) == "$") {
+                  branchNamePattern = branchNamePattern.substring(0, branchNamePattern.length-1)
+                }
                 // parses the output of git branch --verbose --verbose
                 // only match branch names with supported characters (see webui.branchNamePattern)
-                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ webui.branchNamePattern.source.substring(1,webui.branchNamePattern.source.length-1) +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
+                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ branchNamePattern +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
                 var matches = reMatchGitBranchOutput.exec(ref);
                 if (!matches) {
                     $(cardDiv).remove();

--- a/git-webui/src/share/git-webui/webui/js/git-webui.js
+++ b/git-webui/src/share/git-webui/webui/js/git-webui.js
@@ -474,7 +474,7 @@ webui.SideBarView = function(mainView, noEventHandlers) {
             if (id.indexOf("local-branches") > -1) {
                 // parses the output of git branch --verbose --verbose
                 // only match branch names with supported characters (see webui.branchNamePattern)
-                var reMatchGitBranchOutput = new RegExp("^\*?\s*("+ webui.branchNamePattern.source +")\s+([^\s]+)\s+(\[.*\])?.*")
+                var reMatchGitBranchOutput = new RegExp("^\\*?\\s*("+ webui.branchNamePattern.source.substring(1,webui.branchNamePattern.source.length-1) +")\\s+([^\\s]+)\\s+(\\[.*\\])?.*")
                 var matches = reMatchGitBranchOutput.exec(ref);
                 if (!matches) {
                     $(cardDiv).remove();


### PR DESCRIPTION
## Description
Tried latest main branch on Studio and noticed there was an error when opening Git UI about invalid quantifier pointing at line 477 in `git-webui.js` - likely caused by the initial `\*` not being escaped and being treated as a regex operator.

After fixing this did not get any local branches listed in Studio or VS Code. After some investigating determined the following:
- Backslash characters not correctly escaped.
- `webui.branchNamePattern.source` starts and ends with `^` and `$` respectively, which do not work when inserted into the middle of another regular expression so chop off the first and last characters to avoid this.

## Testing
Tested locally on my own IRIS instance with several local branches. With VS Code and Studio.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [N/A] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
