### PR TITLE
IncrementalLoad pull handler work queue manager to import and delete items in parallel in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ImportAll` imports items in parallel when `compileOnImport` and `decomposeProductions` are both disabled, reducing import time for large codebases (#970)
+- The Incremental Load pull event handler can import and delete items in parallel when `decomposeProductions` is disabled, reducing the time required for various operations (#973)
 - Import of decomposed production items now has a brief timeout in case another deploy is in progress (#949)
 - Option to view an individual file's history in the source control menu (#960)
 - Change context menu now lists IPM packages from all Git-enabled namespaces, prefixed with the namespace name (#952)

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -116,7 +116,7 @@ Method OnPull() As %Status
     quit sc
 }
 
-Method RemoveItem(pInternalName, pExternalName) As %Status
+ClassMethod RemoveItem(pInternalName, pExternalName) As %Status
 {
     #Dim delSC As %Status
     set delSC = ..DeleteFile(pInternalName, pExternalName)
@@ -129,7 +129,7 @@ Method RemoveItem(pInternalName, pExternalName) As %Status
     quit delSC
 }
 
-Method DeleteFile(item As %String = "", externalName As %String = "") As %Status
+ClassMethod DeleteFile(item As %String = "", externalName As %String = "") As %Status
 {
     #Dim sc As %Status = $$$OK
     #Dim err As %Exception.AbstractException

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -20,6 +20,17 @@ Method OnPull() As %Status
         }
     }
 
+    // Create a work queue manager to use for importing items to improve performance
+    // Currently only used when not using decomposed productions
+    #dim queue as %SYSTEM.WorkMgr = ""
+    set settings = ##class(SourceControl.Git.Settings).%New()
+    if ('settings.decomposeProductions) {
+        set queue = ##class(%SYSTEM.WorkMgr).%New()
+        if (queue = "") {
+            set sc = $$$ADDSC(sc, %objlasterror)
+        }
+    }
+
     set nFiles = 0
     for i=1:1:$get(..ModifiedFiles){
         set internalName = ..ModifiedFiles(i).internalName
@@ -45,9 +56,19 @@ Method OnPull() As %Status
                 set ptdList(internalName) = ""
             } else {
                 set compilelist(internalName) = ""
-                set sc = $$$ADDSC(sc,##class(SourceControl.Git.Utils).ImportItem(internalName, 1))
+                // If a work queue has been created then use it
+                if (queue '= "") {
+                    set sc = $$$ADDSC(sc, queue.Queue("##class(SourceControl.Git.Utils).ImportItem", internalName, 1))
+                } else {
+                    set sc = $$$ADDSC(sc, ##class(SourceControl.Git.Utils).ImportItem(internalName, 1))
+                }
             }
         }
+    }
+
+    // If a work queue was created then wait for all work to finish
+    if (queue '= "") {
+        set sc = $$$ADDSC(sc, queue.Sync())
     }
 
     #; First remove production items, then everything else

--- a/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
+++ b/cls/SourceControl/Git/PullEventHandler/IncrementalLoad.cls
@@ -20,7 +20,7 @@ Method OnPull() As %Status
         }
     }
 
-    // Create a work queue manager to use for importing items to improve performance
+    // Create a work queue manager to use for importing and deleting items to improve performance
     // Currently only used when not using decomposed productions
     #dim queue as %SYSTEM.WorkMgr = ""
     set settings = ##class(SourceControl.Git.Settings).%New()
@@ -76,10 +76,21 @@ Method OnPull() As %Status
     for orderIndex = 1,2 {
         set item = $order(delList(orderIndex, ""), 1, tExternalName)
         while (item '= "") {
-            set delSC = ..RemoveItem(item, tExternalName)
+            // If a work queue has been created then use it
+            if (queue '= "") {
+                set delSC = queue.Queue("..RemoveItem", item, tExternalName)
+            } else {
+                set delSC = ..RemoveItem(item, tExternalName)
+            }
             set item = $order(delList(orderIndex, item), 1, tExternalName)
         }
     }
+
+    // If a work queue was created then wait for all work to finish
+    if (queue '= "") {
+        set sc = $$$ADDSC(sc, queue.Sync())
+    }
+
     if (nFiles = 0) {
         write !, "Nothing to Load."
         quit $$$OK


### PR DESCRIPTION
## Description
Use a work queue manager in the Incremental Load pull event handler for both importing and deleting files. Similar to what was done in #970

Results in a pleasing performance improvement to anything that uses the pull event handler such as revert, switching branches and this also now covers Import All when `compileOnImport` is enabled - something that was not covered in #970 

The work queue manager is not used when `decomposeProductions` is enabled as I do not use this feature, have limited experience with it and I suspect that additional locking or other more complicated changes would be required to allow decomposed production items to safely create/update/delete productions in parallel.

## Testing
Tested locally with pulls of various sizes (including 1000+ files) and other actions that use the pull event handler such as: revert, switching branches and Import All with `compileOnImport` enabled.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
