### PR TITLE
Customize IPM load flags used by pull event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change context menu now lists IPM packages from all Git-enabled namespaces, prefixed with the namespace name (#952)
 - Pull event handler option in settings page now displays user-friendly names for options (#908)
 - Validation that SSH key file path is not a directory when configuring Embedded Git (#943)
+- Customization of IPM load flags using `##class(SourceControl.Git.PullEventHandler.PackageManager).ConfigureLoadFlags(.flags)` (#974)
 
 ### Fixed
 - Changes to % routines mapped to the current namespace may now be added to source control and committed (#944)

--- a/cls/SourceControl/Git/PullEventHandler/PackageManager.cls
+++ b/cls/SourceControl/Git/PullEventHandler/PackageManager.cls
@@ -9,11 +9,8 @@ Parameter DESCRIPTION = "Does zpm ""load <repo root>""";
 Method OnPull() As %Status
 {
     set command = "load "_..LocalRoot
-    set key = $order(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",""))
-    while (key '= "") {
-        set command = command _ " -" _ $zstrip(key,"*W") _ "=" _ $zstrip(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key),"*W")
-        set key = $order(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key))
-    }
+    set additionalFlags = ..GetLoadFlags()
+    if (additionalFlags'="") set command = command _ " " _ additionalFlags
     quit $select(
         $$$comClassDefined("%IPM.Main"): ##class(%IPM.Main).Shell(command),
         1: ##class(%ZPM.PackageManager).Shell(command)
@@ -23,17 +20,16 @@ Method OnPull() As %Status
 /// Configures additional flags to be used with zpm "load" by Package Manager pull event handlers
 /// Example: to use `zpm "load -DNoMapping=1"` run the following:
 /// ```
-/// kill flags set flags("DNoMapping") = 1
-/// do ##class(SourceControl.Git.PullEventHandler.PackageManager).ConfigureLoadFlags(.flags)
+/// do ##class(SourceControl.Git.PullEventHandler.PackageManager).ConfigureLoadFlags("-DNoMapping=1")
 /// ```
-ClassMethod ConfigureLoadFlags(ByRef flags)
+ClassMethod ConfigureLoadFlags(flags = "")
 {
-    kill @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags")
-    set key = $order(flags(""))
-    while (key '= "") {
-        set @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key) = flags(key)
-        set key = $order(flags(key))
-    }
+    set @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags") = flags
+}
+
+ClassMethod GetLoadFlags() As %String
+{
+    return $get(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags"))
 }
 
 }

--- a/cls/SourceControl/Git/PullEventHandler/PackageManager.cls
+++ b/cls/SourceControl/Git/PullEventHandler/PackageManager.cls
@@ -9,10 +9,31 @@ Parameter DESCRIPTION = "Does zpm ""load <repo root>""";
 Method OnPull() As %Status
 {
     set command = "load "_..LocalRoot
+    set key = $order(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",""))
+    while (key '= "") {
+        set command = command _ " -" _ $zstrip(key,"*W") _ "=" _ $zstrip(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key),"*W")
+        set key = $order(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key))
+    }
     quit $select(
         $$$comClassDefined("%IPM.Main"): ##class(%IPM.Main).Shell(command),
         1: ##class(%ZPM.PackageManager).Shell(command)
     )
+}
+
+/// Configures additional flags to be used with zpm "load" by Package Manager pull event handlers
+/// Example: to use `zpm "load -DNoMapping=1"` run the following:
+/// ```
+/// kill flags set flags("DNoMapping") = 1
+/// do ##class(SourceControl.Git.PullEventHandler.PackageManager).ConfigureLoadFlags(.flags)
+/// ```
+ClassMethod ConfigureLoadFlags(ByRef flags)
+{
+    kill @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags")
+    set key = $order(flags(""))
+    while (key '= "") {
+        set @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags",key) = flags(key)
+        set key = $order(flags(key))
+    }
 }
 
 }

--- a/cls/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
+++ b/cls/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
@@ -1,4 +1,4 @@
-Class SourceControl.Git.PullEventHandler.PackageManagerReload Extends SourceControl.Git.PullEventHandler
+Class SourceControl.Git.PullEventHandler.PackageManagerReload Extends SourceControl.Git.PullEventHandler.PackageManager
 {
 
 Parameter NAME = "Package Manager Reload";
@@ -20,11 +20,8 @@ Method OnPull() As %Status
         )
         $$$QuitOnError(sc)
     }
-    set command = "load "_..LocalRoot
-    quit $select(
-        $$$comClassDefined("%IPM.Main"): ##class(%IPM.Main).Shell(command),
-        1: ##class(%ZPM.PackageManager).Shell(command)
-    )
+    /// super class loads the IPM package
+    return ##super()
 }
 
 }

--- a/test/UnitTest/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
+++ b/test/UnitTest/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
@@ -1,0 +1,41 @@
+/// integration tests for the Package Manager Reload pull event handler
+Class UnitTest.SourceControl.Git.PullEventHandler.PackageManagerReload Extends UnitTest.SourceControl.Git.AbstractTest
+{
+
+Method TestLoadUninstallsThenInstalls()
+{
+    set testModulePath = ##class(SourceControl.Git.PackageManagerContext).ForInternalName("git-source-control.zpm").Package.Root_"test/_resources/simplest-module"
+    set pullEventHandler = ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).%New()
+    set pullEventHandler.LocalRoot = testModulePath
+    // pull once to install simplest-module
+    do $$$AssertStatusOK(pullEventHandler.OnPull())
+    // pull again to verify uninstall + install
+    do $$$AssertStatusOK(pullEventHandler.OnPull())
+    set history = ##class(%IPM.General.History).GetHistory(,,2)
+    do $$$AssertTrue(history.%Next())
+    do $$$AssertEquals(history.Action,"load")
+    do $$$AssertTrue(history.%Next())
+    do $$$AssertEquals(history.Action,"uninstall")
+    do $$$AssertEquals(history.CommandString,"uninstall simplest-module")
+    zpm "uninstall simplest-module"
+}
+
+Method TestLoadUsesConfiguredFlags()
+{
+    set testModulePath = ##class(SourceControl.Git.PackageManagerContext).ForInternalName("git-source-control.zpm").Package.Root_"test/_resources/simplest-module"
+    kill initFlags
+    merge initFlags = @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags")
+    kill flags set flags("DNoMapping") = 1
+    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(.flags)
+    set pullEventHandler = ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).%New()
+    set pullEventHandler.LocalRoot = testModulePath
+    do $$$AssertStatusOK(pullEventHandler.OnPull())
+    set history = ##class(%IPM.General.History).GetHistory(,,2)
+    do $$$AssertTrue(history.%Next())
+    do $$$AssertEquals(history.Action,"load")
+    do $$$AssertEquals(history.CommandString, "load "_testModulePath_" -DNoMapping=1")
+    zpm "uninstall simplest-module"
+    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(.initFlags)
+}
+
+}

--- a/test/UnitTest/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
+++ b/test/UnitTest/SourceControl/Git/PullEventHandler/PackageManagerReload.cls
@@ -23,19 +23,18 @@ Method TestLoadUninstallsThenInstalls()
 Method TestLoadUsesConfiguredFlags()
 {
     set testModulePath = ##class(SourceControl.Git.PackageManagerContext).ForInternalName("git-source-control.zpm").Package.Root_"test/_resources/simplest-module"
-    kill initFlags
-    merge initFlags = @##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags")
-    kill flags set flags("DNoMapping") = 1
-    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(.flags)
+    set initFlags = $get(@##class(SourceControl.Git.Utils).#Storage@("settings","IPM","loadFlags"))
+    set flags = "-DNoMapping=1 -extra-pip-flags ""--timeout 30"""
+    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(flags)
     set pullEventHandler = ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).%New()
     set pullEventHandler.LocalRoot = testModulePath
     do $$$AssertStatusOK(pullEventHandler.OnPull())
     set history = ##class(%IPM.General.History).GetHistory(,,2)
     do $$$AssertTrue(history.%Next())
     do $$$AssertEquals(history.Action,"load")
-    do $$$AssertEquals(history.CommandString, "load "_testModulePath_" -DNoMapping=1")
+    do $$$AssertEquals(history.CommandString, "load "_testModulePath_" -DNoMapping=1 -extra-pip-flags ""--timeout 30""")
     zpm "uninstall simplest-module"
-    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(.initFlags)
+    do ##class(SourceControl.Git.PullEventHandler.PackageManagerReload).ConfigureLoadFlags(initFlags)
 }
 
 }

--- a/test/_resources/simplest-module/module.xml
+++ b/test/_resources/simplest-module/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+  <Document name="simplest-module.ZPM">
+    <Module>
+      <Name>simplest-module</Name>
+      <Version>1.0.0</Version>
+      <Packaging>module</Packaging>
+    </Module>
+  </Document>
+</Export>


### PR DESCRIPTION
## Description
Resolves #974
You can now configure custom load flags to be used by the IPM event handlers. This is enough of a niche that for now I'm not adding this setting to the Configure() API or the Settings page.

## Testing
Unit test class is an integration test of the PackageManagerReload event handler, covering the existing and new behavior.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
