### PR TITLE
fix: deploying production items no longer tries to load unrelated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure prompt no longer quits out with an unhelpful error if existing boolean settings are null (#962)
 - Branch names are now constrained to a reasonable set of allowed characters, fixing an issue where branch names with special characters were hidden without explanation (#914)
 - PTD documents that are not decomposed production items may now be added to source control (#965)
+- Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
 
 ## [2.16.0] - 2026-03-06
 

--- a/cls/SourceControl/Git/Production.cls
+++ b/cls/SourceControl/Git/Production.cls
@@ -335,7 +335,8 @@ ClassMethod GetModifiedItemsAfterSave(internalName As %String, Output modifiedIt
     } else {
 	    // If editing/adding/deleting from Studio, VS Code, or Interop Editor UI, mark all items for edit then find adds/deletes
 	    if source = "IDE" {
-		    // only compile f editing from IDE
+			// if editing from IDE, compile to populate the Ens_Config.Item tables, but do not trigger source control hooks.
+			new %SourceControl
 	    	$$$ThrowOnError($System.OBJ.Compile(productionName, "ck-d/multicompile=0"))
 	    }
         set productionConfig = ##class(Ens.Config.Production).%OpenId(productionName)

--- a/test/UnitTest/SourceControl/Git/ProductionDecomposition.cls
+++ b/test/UnitTest/SourceControl/Git/ProductionDecomposition.cls
@@ -122,6 +122,26 @@ Method TestImportItemsWithError()
     do $$$AssertStatusOK(##class(SourceControl.Git.Utils).ImportItem("UnitTest.SampleProduction||Settings-a|Ens.Activity.Operation.Local.PTD"))
 }
 
+Method TestStrayUncommittedPTDDoesNotBreakSave()
+{
+    new %SourceControl
+    do $System.OBJ.Delete(..#ProductionName)
+    $$$ThrowOnError(##class(SourceControl.Git.Production).CreateProduction(..#ProductionName))
+    do ##class(%Studio.SourceControl.Interface).SourceControlCreate()
+
+    do $$$LogMessage("an unrelated non-class PTD left uncommitted in the queue")
+    do ##class(Ens.Util.ProjectTextDocument).Delete("UnitTest.Git.Demo.PTD")
+    $$$ThrowOnError(##class(Ens.Util.ProjectTextDocument).Create("plain text not loadable as a class","UnitTest.Git.Demo","stray PTD"))
+    $$$ThrowOnError(##class(SourceControl.Git.Utils).AddToSourceControl("UnitTest.Git.Demo.PTD"))
+    // intentionally not committed: it stays in the uncommitted queue that RefreshUncommitted walks
+    set strayFile = ##class(SourceControl.Git.Utils).FullExternalName("UnitTest.Git.Demo.PTD")
+    do $$$AssertTrue(##class(SourceControl.Git.Change).IsUncommitted(strayFile))
+
+    do $$$LogMessage("saving the decomposed production must succeed despite the stray PTD in the queue")
+    $$$ThrowOnError(%SourceControl.OnBeforeSave(..#ProductionName_".cls"))
+    do $$$AssertStatusOK(%SourceControl.OnAfterSave(..#ProductionName_".cls"))
+}
+
 /// PTD documents that do not represent decomposed production items may be added to source control as .PTD files
 Method TestNonHostPTD()
 {


### PR DESCRIPTION
## Description
Fixes #977 

The code path leading to the bug is: User tries to deploy a change through the deployment manager, while having an unrelated item in the Git repository. It calls the source control extension OnAfterSave hooks. OnAfterSave calls GetModifiedItemsAfterSave. For an unknown reason it goes through the code path for edits from an IDE rather than the Interoperability Portal (not worth tracing down, as it should work either way). GetModifiedItemsAfterSave recompiles the production to regenerate the Ens_Config.Item table so we can query it to find if items were added/deleted. (MODIFICATION HERE.) The recompile calls the source control extension OnAfterCompile hooks, which calls RefreshUncommitted, which calls ExternalNameToInternalName, which does a test load of each modified item in the git repo, which fails for some totally unrelated item. Since the load fails inside of a compile, the compile returns a failure, the whole deployment ends up failing.

Where I say MODIFICATION HERE: we `new %SourceControl` to break the chain. We should not be calling source control hooks when doing that compile.

## Testing
Unit test case replicates reported bug. Before the fix it failed, now it succeeds.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
