### PR TITLE
chore: fix changelog after merging 977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.1] - Unreleased
+
+### Fixed
+- Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
+
 ## [2.17.0] - 2026-06-22
 
 ### Added
@@ -23,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure prompt no longer quits out with an unhelpful error if existing boolean settings are null (#962)
 - Branch names are now constrained to a reasonable set of allowed characters, fixing an issue where branch names with special characters were hidden without explanation (#914)
 - PTD documents that are not decomposed production items may now be added to source control (#965)
-- Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
 
 ## [2.16.0] - 2026-03-06
 


### PR DESCRIPTION
A PR got merged after a release, so it ended up in the wrong place in the changelog. this has been fixed.