### PR TITLE
Fix compile new bpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
+- Fixed bug causing compilation errors when first adding an IRIS Interoperability BPL or BR (#984)
 
 ## [2.17.0] - 2026-06-22
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -597,9 +597,15 @@ Method CheckBusinessProcessesAndRules(InternalName As %String) As %Status
     //       so we have to add them like this
     if (##class(SourceControl.Git.Utils).Type(InternalName) = "cls") {
         set name = $piece(InternalName,".CLS",1)
-        set exists = ##class(%Dictionary.CompiledClass).%ExistsId(name)
-        if (exists && ($classmethod(name,"%Extends","Ens.BusinessProcess") || $classmethod(name,"%Extends","Ens.Rule.Definition"))) {
-            do ..AddToSourceControl(InternalName)
+        if '##class(%Dictionary.CompiledClass).%ExistsId(name) quit
+        if '$system.CLS.IsMthd(name, "%Extends") quit
+        try {
+            if ($classmethod(name,"%Extends","Ens.BusinessProcess") || $classmethod(name,"%Extends","Ens.Rule.Definition")) {
+                do ..AddToSourceControl(InternalName)
+            }
+        } catch err {
+            // even if compiled class exists, we can get CLASS DOES NOT EXIST - ignore these
+            if '(err.AsStatus() [ "CLASS DOES NOT EXIST") throw err
         }
     }
 }

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -2455,6 +2455,7 @@ ClassMethod GitStatus(ByRef files, IncludeAllFiles = 0)
     set list = $listfromstring(lines, $char(0))
     set pointer = 0
     while $listnext(list, pointer, item) {
+        continue:item=""
         set operation = $zstrip($extract(item, 1, 2), "<>W")
         set externalName = $extract(item, 4, *)
         set internalName = ..NameToInternalName(externalName,0,0)


### PR DESCRIPTION
## Description
Resolves #984 
Fixes two unrelated bugs causing compilation failures:
- logic to auto add bpl/br to source control assumed that if compiled class dictionary exists it is runnable, which is apparently not true
- RefreshUncommitted calls a git status and output is incorrectly parsed, leading it to try to look up internal name for an empty string.

## Testing
A little hard to unit test because it only occurs in certain edge cases in the compile chain. Manual testing:
docker compose up -d --build
do ##class(SourceControl.Git.API).Configure()
enter in prompts to initialize git repository, accepting all other defaults.
http://localhost:52774/csp/sys/UtilHome.csp
Create a new business process (simplest compilable one: just add one Trace block, set value to 1, then hook it up to the input and output).
Save the business process
Compile. Prior to this change, it failed to compile. Now, it successfully compiles.
Open Git Web UI and confirm the new business process was automatically exported to the Git workspace.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
