### PR TITLE
Fixed error compiling new BPL in new interoperability editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
-- Fixed bug causing compilation errors when first adding an IRIS Interoperability BPL or BR (#984)
+- Fixed bugs causing compilation errors when first adding an IRIS Interoperability BPL or BR (#984)
 
 ## [2.17.0] - 2026-06-22
 

--- a/cls/SourceControl/Git/Extension.cls
+++ b/cls/SourceControl/Git/Extension.cls
@@ -461,12 +461,15 @@ Method OnAfterDelete(InternalName As %String) As %Status
 /// change in the class. The <var>Location</var> is the global reference to the class definition that was changed.
 Method OnAfterStorage(InternalName As %String, Location As %String = "") As %Status
 {
+    $$$SuspendErrorCount
     if (InternalName '= "") {
         write !,"Item '"_InternalName_"' changed during compile so exporting new version."
         set ..Modified(InternalName) = 1
         set sc = ..OnAfterSave(InternalName)
         if $$$ISERR(sc) {
             do $System.OBJ.DisplayError(sc)
+            do $System.Status.DecomposeStatus(sc, .errorlog)
+            $$$IncErrorNums(errorlog)
         }
     }
     return $$$OK


### PR DESCRIPTION
## Description
Fixes #984 
A workaround for OnAfterStorage hooks in the ObjectScript class compiler incorrectly reporting errors.

## Testing
In the docker container, create a new business process in the new BPL editor. Save and compile. It should succeed, and the BPL class should be automatically exported to the git repository

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
