### PR TITLE
Custom studio docs are imported with the correct character encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.17.1] - Unreleased
 
 ### Fixed
+- Fixed corruption of non-ASCII characters when importing lookup tables and other custom Studio documents (#990)
 - Fixed a bug where interop deployment manager would in some cases fail because it tried to load unrelated items from the repo (#977)
 - Fixed bugs causing compilation errors when first adding an IRIS Interoperability BPL or BR (#984)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=containers.intersystems.com/intersystems/iris-community:2025.1
+ARG BASE=containers.intersystems.com/intersystems/iris-community:2026.1
 
 FROM ${BASE}
 

--- a/cls/SourceControl/Git/Utils.cls
+++ b/cls/SourceControl/Git/Utils.cls
@@ -1503,6 +1503,8 @@ ClassMethod ImportItem(InternalName As %String, force As %Boolean = 0, verbose A
             do routineMgr.Code.Rewind()
             set source = ##class(%Stream.FileCharacter).%OpenId(filename,,.sc)
             if $$$ISOK(sc) {
+                // with no charset defined, ExportUDL uses UTF8 by default. explicitly match that on import.
+                set source.TranslateTable = $select($$$IsUnicode:"UTF8",1:"RAW")
                 do routineMgr.Code.CopyFrom(source)
                 set sc = routineMgr.%Save()
             }

--- a/test/UnitTest/SourceControl/Git/Utils/ImportItem.cls
+++ b/test/UnitTest/SourceControl/Git/Utils/ImportItem.cls
@@ -1,5 +1,86 @@
+Include SourceControl.Git
+
 Class UnitTest.SourceControl.Git.Utils.ImportItem Extends UnitTest.SourceControl.Git.AbstractTest
 {
+
+/// Tests that non-ASCII characters in a lookup table survive an export/import
+/// round trip. Lookup tables are Studio user documents, so ImportItem reads them
+/// with a %Stream.FileCharacter; if that stream's TranslateTable does not match
+/// the UTF-8 that ExportUDL writes, the UTF-8 bytes are decoded one byte at a
+/// time and "µ" (one char) becomes "Âµ" (two chars). (#990)
+Method TestLookupTableUnicodeRoundTrip()
+{
+    if '##class(%Library.EnsembleMgr).IsEnsembleNamespace() {
+        do $$$LogMessage("Not an interoperability namespace, skipping lookup table test")
+        quit
+    }
+
+    set tableName = "UnitTestGitUnicode"
+    set internalName = tableName_".LUT"
+    // U+00B5 MICRO SIGN: one character, encoded in UTF-8 as the two bytes $c(194,181)
+    set micro = $char(181)
+    set expectedKey = micro_"mol/L"
+    set expectedValue = micro_"g/dL"
+
+    set $$$SourceMapping("LUT","*") = "data/lut/"
+    set $$$SourceMapping("LUT","*","NoFolders") = 1
+
+    do ..DeleteLookupTable(tableName)
+    set rs = ##class(%SQL.Statement).%ExecDirect(,"INSERT INTO Ens_Util.LookupTable (TableName,KeyName,DataValue) VALUES (?,?,?)",tableName,expectedKey,expectedValue)
+    $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
+    do $$$AssertTrue(##class(%RoutineMgr).Exists(internalName), "lookup table document exists after seeding")
+
+    set filename = ##class(SourceControl.Git.Utils).FullExternalName(internalName)
+    do $$$AssertStatusOK(##class(SourceControl.Git.Utils).ExportItem(internalName, 1, 1))
+
+    // Pin the on-disk encoding. Without this the round trip could pass with both
+    // halves consistently wrong, and the regression would go unnoticed.
+    set onDisk = ..ReadBytes(filename)
+    do $$$AssertTrue($find(onDisk, $char(194)_$char(181)) > 0, "exported file encodes the micro sign as UTF-8 $c(194,181)")
+    do $$$AssertTrue($find(onDisk, $char(195)_$char(130)) = 0, "exported file is not double-encoded")
+
+    // Drop the in-database copy so the import has to rebuild it from the file,
+    // which is what a branch switch or merge does.
+    do ..DeleteLookupTable(tableName)
+    do $$$AssertStatusOK(##class(SourceControl.Git.Utils).ImportItem(internalName, 1, 0), "ImportItem succeeds")
+
+    set rs = ##class(%SQL.Statement).%ExecDirect(,"SELECT KeyName,DataValue FROM Ens_Util.LookupTable WHERE TableName=?",tableName)
+    $$$ThrowSQLIfError(rs.%SQLCODE, rs.%Message)
+    do $$$AssertTrue(rs.%Next(), "lookup table has a row after import")
+    set actualKey = rs.KeyName
+    set actualValue = rs.DataValue
+
+    // Assert on character codes, not on string equality: the terminal and any
+    // string comparison can both render mangled text as if it were correct.
+    do $$$AssertEquals($length(actualKey), $length(expectedKey), "imported key length is unchanged (mangling adds a character)")
+    do $$$AssertEquals($ascii(actualKey, 1), 181, "imported key starts with the micro sign, not $c(194)")
+    do $$$AssertEquals(actualKey, expectedKey, "imported key round trips")
+    do $$$AssertEquals($ascii(actualValue, 1), 181, "imported value starts with the micro sign, not $c(194)")
+    do $$$AssertEquals(actualValue, expectedValue, "imported value round trips")
+
+    do ..DeleteLookupTable(tableName)
+    if ##class(%File).Exists(filename) {
+        do ##class(%File).Delete(filename)
+    }
+    kill ^SYS("SourceControl","Git","TSH",internalName)
+}
+
+/// Reads a file one byte per character so callers can assert on exact encoding.
+ClassMethod ReadBytes(filePath) As %String [ Private ]
+{
+    set stream = ##class(%Stream.FileBinary).%New()
+    $$$ThrowOnError(stream.LinkToFile(filePath))
+    set bytes = ""
+    while 'stream.AtEnd {
+        set bytes = bytes_stream.Read(4096)
+    }
+    quit bytes
+}
+
+ClassMethod DeleteLookupTable(tableName) [ Private ]
+{
+    do ##class(%SQL.Statement).%ExecDirect(,"DELETE FROM Ens_Util.LookupTable WHERE TableName=?",tableName)
+}
 
 /// Tests that ImportItem does not store a negative error code in the TSH global
 /// and that GetTempFileAndRoutineTS does not throw <VALUE OUT OF RANGE> when


### PR DESCRIPTION
## Description
Fixes #990 
Relevant historical context is in #176

## Testing
Unit test covers the full export/import cycle described in the linked bug. Confirmed that the unit test fails without the translate table fix.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [N/A] Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)
- [x] CHANGELOG.md entry added if appropriate.
- [N/A] Documentation has been/will be updated
