### PR TITLE
Log pull handler bootstrap failure

### DIFF
--- a/cls/SourceControl/Git/DeploymentLog.cls
+++ b/cls/SourceControl/Git/DeploymentLog.cls
@@ -11,6 +11,11 @@ Property HeadRevision As %String;
 
 Property Status As %Status;
 
+Method StartLog(pRevision As %String, pTimestamp AS %TimeStamp = {$zdatetime($ztimestamp,3)}) {
+    set ..HeadRevision = pRevision
+    set ..StartTimestamp = pTimestamp
+}
+
 Method FinalizeLog(pStatus As %Status, pTimestamp AS %TimeStamp = {$zdatetime($ztimestamp,3)}) {
     set ..Status = pStatus
     set ..EndTimestamp = pTimestamp

--- a/cls/SourceControl/Git/DeploymentLog.cls
+++ b/cls/SourceControl/Git/DeploymentLog.cls
@@ -11,6 +11,11 @@ Property HeadRevision As %String;
 
 Property Status As %Status;
 
+Method FinalizeLog(pStatus As %Status, pTimestamp AS %TimeStamp = {$zdatetime($ztimestamp,3)}) {
+    set ..Status = pStatus
+    set ..EndTimestamp = pTimestamp
+}
+
 Storage Default
 {
 <Data name="DeploymentLogDefaultData">

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -34,8 +34,7 @@ ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
             $data(pullEventClass)#2: pullEventClass,
             1: ##class(SourceControl.Git.Utils).PullEventClass())
         set log = ##class(SourceControl.Git.DeploymentLog).%New()
-        set log.HeadRevision = ##class(SourceControl.Git.Utils).GetCurrentRevision()
-        set log.StartTimestamp = $zdatetime($ztimestamp,3)
+        do log.StartLog(##class(SourceControl.Git.Utils).GetCurrentRevision())
         set st = log.%Save()
         quit:$$$ISERR(st)
         set st = ..BootstrapPullEventHandler(handlerClass)
@@ -53,8 +52,7 @@ ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
         catch pullError {
             set st = pullError.AsStatus()
         }
-        set log.EndTimestamp = $zdatetime($ztimestamp,3)
-        set log.Status = st
+        do log.FinalizeLog(st)
         set st = log.%Save()  // this hides any errors returned or thrown by OnPull()
         quit:$$$ISERR(st)
     } catch err {

--- a/cls/SourceControl/Git/PullEventHandler.cls
+++ b/cls/SourceControl/Git/PullEventHandler.cls
@@ -33,13 +33,17 @@ ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
         set handlerClass = $select(
             $data(pullEventClass)#2: pullEventClass,
             1: ##class(SourceControl.Git.Utils).PullEventClass())
-        set st = ..BootstrapPullEventHandler(handlerClass)
-        quit:$$$ISERR(st)
         set log = ##class(SourceControl.Git.DeploymentLog).%New()
         set log.HeadRevision = ##class(SourceControl.Git.Utils).GetCurrentRevision()
         set log.StartTimestamp = $zdatetime($ztimestamp,3)
         set st = log.%Save()
         quit:$$$ISERR(st)
+        set st = ..BootstrapPullEventHandler(handlerClass)
+        if $$$ISERR(st) {
+            do log.FinalizeLog(st)
+            do log.%Save()
+            quit
+        }
         set event = $classmethod(handlerClass,"%New")
         set event.LocalRoot = ##class(SourceControl.Git.Utils).TempFolder()
         merge event.ModifiedFiles = files
@@ -60,7 +64,7 @@ ClassMethod ForModifications(ByRef files, pullEventClass As %String) As %Status
 }
 
 /// Makes sure <var>class</var> is compiled and can be instantiated, loading it from the
-/// local repository if needed. 
+/// local repository if needed.
 ClassMethod BootstrapPullEventHandler(class As %String) As %Status [ Private ]
 {
     quit:$$$comClassDefined(class) $$$OK

--- a/test/UnitTest/SourceControl/Git/DeploymentLog.cls
+++ b/test/UnitTest/SourceControl/Git/DeploymentLog.cls
@@ -1,0 +1,16 @@
+Class UnitTest.SourceControl.Git.DeploymentLog Extends %UnitTest.TestCase
+{
+
+Method TestLogActions() {
+    set log = ##class(SourceControl.Git.DeploymentLog).%New()
+    set timestamp = "2026-09-10 08:20:00"  // Use a static timestamp to verify properties are set.
+    do log.StartLog("face123", timestamp)
+    do $$$AssertEquals(log.HeadRevision, "face123")
+    do $$$AssertEquals(log.StartTimestamp, timestamp)
+
+    do log.FinalizeLog($$$OK, timestamp)
+    do $$$AssertStatusOK(log.Status)
+    do $$$AssertEquals(log.EndTimestamp, timestamp)
+}
+
+}


### PR DESCRIPTION
This is a follow up to PR #1005 for #1000

## Description
- Embedded Git should capture if loading a custom pull event handler fails in a `DeploymentLog` entry because not every call to `ForModifications()` displays the return status in the event of an error.
- Refactored: extracted named methods within `DeploymentLog` to make the flow within `ForModifications()` a little more human readable and avoid duplicate property sets.
    - Added a Unit Test

## Testing
I added a unit test case, but I only have the ability to compile code and run things in terminal.  Unfortunately, I am not in a position to fully configure my current Iris instance to run the test suite at the moment.

## Checklist
- [x] This branch has the latest changes from the `main` branch rebased or merged.
- [x] ~Web UI has been built (any changes in `git-webui/src` have matching changes in `git-webui/release`)~
- [x] CHANGELOG.md entry added if appropriate.
- [x] Documentation has been/will be updated
